### PR TITLE
Feature/edit user and user custom tags

### DIFF
--- a/apps/backend/src/application/identity/discover-users.use-case.ts
+++ b/apps/backend/src/application/identity/discover-users.use-case.ts
@@ -113,8 +113,8 @@ export class DiscoverUsersUseCase {
    * Mapea una entidad User a IUserPublicProfile
    * Extrae solo campos públicos, excluye datos sensibles
    * 
-   * EXCLUIDO: email, phone, passwordHash, subscription, notifications
-   * INCLUIDO: id, companyName, type, serviceAreas (providers), isVerified (providers)
+   * EXCLUIDO: email, phone, passwordHash, subscription, notifications, address
+   * INCLUIDO: id, companyName, bio, tags, type, serviceAreas (providers), isVerified (providers)
    * 
    * @private
    */
@@ -122,7 +122,9 @@ export class DiscoverUsersUseCase {
     const baseProfile: IUserPublicProfile = {
       id: user.id.getValue(),
       profile: {
-        companyName: user.profile.companyName
+        companyName: user.profile.companyName,
+        bio: user.profile.bio, // 🆕 Sprint #13 Task 10.2: Biografía pública
+        tags: user.profile.tags // 🆕 Sprint #13 Task 10.2: Tags públicos
       },
       type: user.type
     };
@@ -133,7 +135,7 @@ export class DiscoverUsersUseCase {
         ...baseProfile,
         serviceAreas: user.specialties, // Map specialties to serviceAreas for public API
         isVerified: user.isVerified
-      };
+      } as IUserPublicProfile;
     }
 
     // ClientUser: solo campos base
@@ -144,6 +146,15 @@ export class DiscoverUsersUseCase {
     //   return {
     //     ...baseProfile,
     //     machineCount: user.machineCount // Mostrar experiencia del cliente
+    //   };
+    // }
+    // TODO: Rating y estadísticas
+    // if (user instanceof ProviderUser) {
+    //   return {
+    //     ...baseProfile,
+    //     rating: user.averageRating, // Rating promedio de trabajos completados
+    //     completedJobs: user.completedJobsCount, // Contador de trabajos finalizados
+    //     responseTime: user.averageResponseTime // Tiempo promedio de respuesta (Module 3: Messaging)
     //   };
     // }
   }

--- a/apps/backend/src/application/identity/list-contacts.use-case.ts
+++ b/apps/backend/src/application/identity/list-contacts.use-case.ts
@@ -75,7 +75,9 @@ export class ListContactsUseCase {
     const baseProfile: IUserPublicProfile = {
       id: user.id.getValue(),
       profile: {
-        companyName: user.profile.companyName
+        companyName: user.profile.companyName,
+        bio: user.profile.bio, // 🆕 Sprint #13 Task 10.2: Biografía pública
+        tags: user.profile.tags // 🆕 Sprint #13 Task 10.2: Tags públicos
       },
       type: user.type
     };
@@ -86,7 +88,7 @@ export class ListContactsUseCase {
         ...baseProfile,
         serviceAreas: user.specialties, // Map specialties to serviceAreas for public API
         isVerified: user.isVerified
-      };
+      } as IUserPublicProfile;
     }
 
     // ClientUser: only base fields

--- a/apps/backend/src/application/identity/login-user.use-case.ts
+++ b/apps/backend/src/application/identity/login-user.use-case.ts
@@ -81,10 +81,7 @@ export class LoginUserUseCase {
       // 4. Retornar respuesta usando método de dominio (SIN passwordHash)
       const publicData = user.toPublicData();
       return {
-        user: {
-          ...publicData,
-          type: publicData.type as UserType // Cast al tipo de contrato esperado
-        },
+        user: publicData as any, // Cast para compatibilidad readonly → mutable (Sprint #13 Task 10.2)
         token: tokens.accessToken,
         refreshToken: tokens.refreshToken,
       };

--- a/apps/backend/src/application/identity/update-user-profile.use-case.ts
+++ b/apps/backend/src/application/identity/update-user-profile.use-case.ts
@@ -1,0 +1,138 @@
+import { UpdateUserRequest } from '@packages/contracts';
+import { UserId } from '@packages/domain';
+import { UserRepository } from '@packages/persistence';
+import { logger } from '../../config/logger.config';
+
+/**
+ * Use Case para actualizar el perfil de un usuario
+ * Sprint #13 Tasks 10.1 + 10.2: User Profile Editing + Bio & Tags
+ * 
+ * Funcionalidad:
+ * - Permite a usuarios editar su propio perfil (phone, companyName, address, bio, tags)
+ * - Ownership verificado por authMiddleware (req.user.userId === userId del request)
+ * - Validaciones en múltiples capas: Zod (contracts) → Entity (domain) → Mongoose (persistence)
+ * 
+ * Campos editables:
+ * - profile.phone (opcional)
+ * - profile.companyName (opcional)
+ * - profile.address (opcional)
+ * - profile.bio (opcional, max 500 chars)
+ * - profile.tags (opcional, max 5 tags, cada uno max 100 chars)
+ * 
+ * Campos NO editables (excluidos de este use case):
+ * - email (requiere verificación separada)
+ * - isActive (solo admins)
+ * - subscriptionLevel / serviceAreas (específicos de tipo, funcionalidad futura)
+ */
+export class UpdateUserProfileUseCase {
+  private userRepository: UserRepository;
+
+  constructor() {
+    this.userRepository = new UserRepository();
+  }
+
+  /**
+   * Ejecuta la actualización del perfil del usuario
+   * 
+   * @param userId - ID del usuario a actualizar (debe coincidir con req.user.userId del JWT)
+   * @param request - Datos de actualización validados por Zod
+   * @returns Promise con datos del usuario actualizado o error
+   * 
+   * Flujo:
+   * 1. Validar userId con Value Object UserId
+   * 2. Obtener entidad User desde repository
+   * 3. Aplicar cambios usando entity.updateProfile() (valida reglas de dominio)
+   * 4. Persistir usando repository.save() (convierte entity → document y actualiza DB)
+   * 5. Retornar usuario actualizado en formato público
+   */
+  async execute(userId: string, request: UpdateUserRequest): Promise<{
+    id: string;
+    email: string;
+    profile: any;
+    type: string;
+    isActive: boolean;
+    createdAt: string;
+    updatedAt: string;
+  }> {
+    logger.info({ userId, updateFields: Object.keys(request.profile || {}) }, 'Starting user profile update');
+
+    try {
+      // 1. Validar userId
+      const userIdResult = UserId.create(userId);
+      if (!userIdResult.success) {
+        logger.warn({ userId }, 'Invalid user ID format');
+        throw new Error('Invalid user ID');
+      }
+
+      // 2. Obtener entidad User existente
+      const userResult = await this.userRepository.findById(userIdResult.data);
+      if (!userResult.success) {
+        logger.warn({ userId }, 'User not found');
+        throw new Error('User not found');
+      }
+
+      const user = userResult.data;
+
+      // 3. Validar que el usuario esté activo (regla de negocio)
+      if (!user.isActive) {
+        logger.warn({ userId }, 'Cannot update inactive user profile');
+        throw new Error('User account is deactivated');
+      }
+
+      // 4. Aplicar actualizaciones de perfil usando método de entidad
+      // updateProfile() valida reglas de dominio (longitudes, formatos, etc.)
+      if (request.profile) {
+        const updateResult = user.updateProfile(request.profile);
+        if (!updateResult.success) {
+          logger.warn({ 
+            userId, 
+            error: updateResult.error.message 
+          }, 'Profile validation failed');
+          throw new Error(updateResult.error.message);
+        }
+      }
+
+      // TODO: Futuro - Manejar actualización de isActive solo para admins
+      // if (request.isActive !== undefined && requestingUserRole === 'ADMIN') {
+      //   if (request.isActive) user.reactivate();
+      //   else user.deactivate();
+      // }
+
+      // 5. Persistir cambios en base de datos
+      const saveResult = await this.userRepository.save(user);
+      if (!saveResult.success) {
+        logger.error({ 
+          userId, 
+          error: saveResult.error.message 
+        }, 'Failed to save user profile updates');
+        throw new Error('Failed to update user profile');
+      }
+
+      logger.info({ 
+        userId, 
+        updatedFields: Object.keys(request.profile || {}),
+        hasBio: !!request.profile?.bio,
+        tagsCount: request.profile?.tags?.length || 0
+      }, '✅ User profile updated successfully');
+
+      // 6. Retornar datos actualizados en formato público
+      return {
+        id: user.id.getValue(),
+        email: user.email.getValue(),
+        profile: user.profile,
+        type: user.type,
+        isActive: user.isActive,
+        createdAt: user.createdAt.toISOString(),
+        updatedAt: user.updatedAt.toISOString()
+      };
+
+    } catch (error) {
+      logger.error({ 
+        error: error instanceof Error ? error.message : 'Unknown error',
+        userId 
+      }, 'User profile update failed');
+      
+      throw error;
+    }
+  }
+}

--- a/apps/backend/src/controllers/user.controller.ts
+++ b/apps/backend/src/controllers/user.controller.ts
@@ -74,16 +74,17 @@ export class UserController {
       }
 
       const userId = req.user.userId;
-      const updateData = req.body;
+      // Extraer solo profile del body (ignorar campo id que viene por Zod pero no se usa)
+      const { profile } = req.body;
 
       logger.info({ 
         userId, 
-        updateFields: Object.keys(updateData.profile || {}),
+        updateFields: Object.keys(profile || {}),
         ip: req.ip 
       }, 'User profile update request received');
 
-      // Ejecutar use case
-      const updatedUser = await this.updateUserProfileUseCase.execute(userId, updateData);
+      // Ejecutar use case con solo el profile field
+      const updatedUser = await this.updateUserProfileUseCase.execute(userId, { profile });
 
       logger.info({ userId }, 'User profile updated successfully');
 

--- a/apps/backend/src/controllers/user.controller.ts
+++ b/apps/backend/src/controllers/user.controller.ts
@@ -1,0 +1,160 @@
+import { Request, Response } from 'express';
+import { UpdateUserProfileUseCase } from '../application/identity/update-user-profile.use-case';
+import { logger } from '../config/logger.config';
+
+/**
+ * Interface para Request autenticado (viene de authMiddleware)
+ */
+interface AuthenticatedRequest extends Request {
+  user?: {
+    userId: string;
+    email: string;
+    type: string;
+    iat: number;
+    exp: number;
+  };
+}
+
+/**
+ * User Controller
+ * Sprint #13 Tasks 10.1 + 10.2: User Profile Editing + Bio & Tags
+ * 
+ * Endpoints:
+ * - PATCH /users/me/profile - Actualizar perfil propio (requiere auth)
+ * 
+ * TODO: Futuras funcionalidades (Sprint #13+)
+ * - GET /users/me/profile - Obtener perfil propio
+ * - GET /users/:userId/public - Ver perfil público de otro usuario
+ * - PATCH /users/me/avatar - Subir avatar (Task 10.3)
+ * - GET /users/suggestions - Buscar usuarios por tags
+ */
+export class UserController {
+  private updateUserProfileUseCase: UpdateUserProfileUseCase;
+
+  constructor() {
+    this.updateUserProfileUseCase = new UpdateUserProfileUseCase();
+  }
+
+  /**
+   * PATCH /users/me/profile
+   * Actualiza el perfil del usuario autenticado
+   * 
+   * Ownership: authMiddleware garantiza que req.user.userId es el usuario autenticado
+   * Solo el usuario puede editar su propio perfil (/me endpoint pattern)
+   * 
+   * Request Body (validado por Zod middleware):
+   * {
+   *   profile?: {
+   *     phone?: string,
+   *     companyName?: string,
+   *     address?: string,
+   *     bio?: string,
+   *     tags?: string[]
+   *   }
+   * }
+   * 
+   * Responses:
+   * - 200: Perfil actualizado exitosamente
+   * - 400: Validación fallida (Zod o domain rules)
+   * - 401: No autenticado (authMiddleware)
+   * - 404: Usuario no encontrado
+   * - 500: Error interno
+   */
+  public updateProfile = async (req: AuthenticatedRequest, res: Response): Promise<void> => {
+    try {
+      // authMiddleware garantiza que req.user existe
+      if (!req.user) {
+        logger.error({ path: req.path }, 'Authenticated request missing user data');
+        res.status(500).json({
+          success: false,
+          message: 'Internal authentication error',
+          error: 'MISSING_USER_DATA'
+        });
+        return;
+      }
+
+      const userId = req.user.userId;
+      const updateData = req.body;
+
+      logger.info({ 
+        userId, 
+        updateFields: Object.keys(updateData.profile || {}),
+        ip: req.ip 
+      }, 'User profile update request received');
+
+      // Ejecutar use case
+      const updatedUser = await this.updateUserProfileUseCase.execute(userId, updateData);
+
+      logger.info({ userId }, 'User profile updated successfully');
+
+      res.status(200).json({
+        success: true,
+        message: 'Profile updated successfully',
+        data: updatedUser
+      });
+
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+      
+      logger.error({
+        error: errorMessage,
+        userId: req.user?.userId,
+        path: req.path
+      }, 'User profile update failed');
+
+      // Mapear errores a códigos HTTP apropiados
+      if (errorMessage.includes('not found')) {
+        res.status(404).json({
+          success: false,
+          message: 'User not found',
+          error: 'USER_NOT_FOUND'
+        });
+        return;
+      }
+
+      if (errorMessage.includes('Invalid') || errorMessage.includes('validation')) {
+        res.status(400).json({
+          success: false,
+          message: errorMessage,
+          error: 'VALIDATION_ERROR'
+        });
+        return;
+      }
+
+      if (errorMessage.includes('deactivated')) {
+        res.status(403).json({
+          success: false,
+          message: 'Cannot update deactivated user profile',
+          error: 'USER_DEACTIVATED'
+        });
+        return;
+      }
+
+      // Error genérico
+      res.status(500).json({
+        success: false,
+        message: 'Failed to update user profile',
+        error: 'UPDATE_FAILED'
+      });
+    }
+  };
+
+  // TODO: Futuros endpoints
+  // 
+  // /**
+  //  * GET /users/me/profile
+  //  * Obtiene el perfil completo del usuario autenticado
+  //  */
+  // public getMyProfile = async (req: AuthenticatedRequest, res: Response): Promise<void> => {
+  //   // Implementation...
+  // };
+  //
+  // /**
+  //  * GET /users/:userId/public
+  //  * Obtiene el perfil público de otro usuario (para User Discovery)
+  //  * Excluye información sensible: email, phone, notifications
+  //  */
+  // public getPublicProfile = async (req: Request, res: Response): Promise<void> => {
+  //   // Implementation...
+  // };
+}

--- a/apps/backend/src/routes/users.routes.ts
+++ b/apps/backend/src/routes/users.routes.ts
@@ -3,7 +3,7 @@ import { requestSanitization } from '../middlewares/requestSanitization';
 import { authMiddleware } from '../middlewares/auth.middleware';
 import { requireRole } from '../middlewares/role-check.middleware';
 import { validateRequest } from '../middlewares/validation.middleware';
-import { UpdateUserRequestSchema } from '@packages/contracts';
+import { UpdateMyProfileRequestSchema } from '@packages/contracts';
 import { UserController } from '../controllers/user.controller';
 
 const router = Router();
@@ -203,7 +203,7 @@ const userController = new UserController();
 router.patch('/me/profile',
   requestSanitization,
   authMiddleware, // Garantiza req.user.userId existe
-  validateRequest({ body: UpdateUserRequestSchema }), // Validación Zod
+  validateRequest({ body: UpdateMyProfileRequestSchema }), // Validación Zod (sin id, viene de JWT)
   userController.updateProfile // Controller invoca use case
 );
 

--- a/apps/backend/src/routes/users.routes.ts
+++ b/apps/backend/src/routes/users.routes.ts
@@ -2,13 +2,210 @@ import { Router } from 'express';
 import { requestSanitization } from '../middlewares/requestSanitization';
 import { authMiddleware } from '../middlewares/auth.middleware';
 import { requireRole } from '../middlewares/role-check.middleware';
+import { validateRequest } from '../middlewares/validation.middleware';
+import { UpdateUserRequestSchema } from '@packages/contracts';
+import { UserController } from '../controllers/user.controller';
 
 const router = Router();
+const userController = new UserController();
 
 /**
  * RUTAS DE USUARIOS
- * Ejemplos de autorización combinada (rol + ownership)
+ * Sprint #13 Tasks 10.1 + 10.2: User Profile Editing + Bio & Tags
+ * 
+ * Nuevas rutas:
+ * - PATCH /me/profile - Actualizar perfil propio (phone, companyName, address, bio, tags)
+ * 
+ * Rutas legacy (ejemplos de autorización combinada rol + ownership):
+ * - GET / - List all users (admin only)
+ * - GET /:userId/profile - Get user profile (admin only, MVP)
+ * - GET /:userId/machines - Get user machines (provider/admin only, MVP)
+ * - GET /directory - Public user directory
  */
+
+/**
+ * @swagger
+ * /api/v1/users/me/profile:
+ *   patch:
+ *     summary: Update own user profile
+ *     description: |
+ *       Allows authenticated users to update their own profile information.
+ *       Ownership is enforced by authMiddleware (only authenticated user can edit their own profile).
+ *       
+ *       **Sprint #13 Tasks 10.1 + 10.2: User Profile Editing + Bio & Tags**
+ *       
+ *       Editable fields:
+ *       - phone (optional, max 20 chars, validated format)
+ *       - companyName (optional, max 100 chars)
+ *       - address (optional, max 200 chars)
+ *       - bio (optional, max 500 chars) - NEW in Sprint #13
+ *       - tags (optional, array max 5, each max 100 chars) - NEW in Sprint #13
+ *       
+ *       Non-editable fields (excluded from this endpoint):
+ *       - email (requires separate verification flow)
+ *       - isActive (admin-only operation)
+ *       - subscriptionLevel / serviceAreas (future functionality)
+ *       
+ *       Validation layers:
+ *       1. Zod schema (contracts) - format & structure validation
+ *       2. Domain entity - business rules validation
+ *       3. Mongoose schema - database constraint validation
+ *     tags: [Users]
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               profile:
+ *                 type: object
+ *                 properties:
+ *                   phone:
+ *                     type: string
+ *                     example: "+123456789"
+ *                     description: Phone number in international format
+ *                   companyName:
+ *                     type: string
+ *                     example: "Fleet Management Solutions Inc."
+ *                     maxLength: 100
+ *                   address:
+ *                     type: string
+ *                     example: "123 Main St, Springfield, USA"
+ *                     maxLength: 200
+ *                   bio:
+ *                     type: string
+ *                     example: "Fleet management company specializing in heavy machinery maintenance and tracking."
+ *                     maxLength: 500
+ *                     description: User/company biography (Sprint #13 Task 10.2)
+ *                   tags:
+ *                     type: array
+ *                     items:
+ *                       type: string
+ *                     example: ["construction", "heavy-machinery", "maintenance", "tracking"]
+ *                     maxItems: 5
+ *                     description: Tags for user discovery and categorization (Sprint #13 Task 10.2, each tag max 100 chars)
+ *           examples:
+ *             updateBioAndTags:
+ *               summary: Update bio and tags
+ *               value:
+ *                 profile:
+ *                   bio: "Leading provider of construction equipment maintenance services in North America."
+ *                   tags: ["construction", "excavators", "maintenance", "certified"]
+ *             updateContactInfo:
+ *               summary: Update contact information
+ *               value:
+ *                 profile:
+ *                   phone: "+1234567890"
+ *                   address: "456 Industrial Ave, Los Angeles, CA"
+ *     responses:
+ *       200:
+ *         description: Profile updated successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success:
+ *                   type: boolean
+ *                   example: true
+ *                 message:
+ *                   type: string
+ *                   example: "Profile updated successfully"
+ *                 data:
+ *                   type: object
+ *                   properties:
+ *                     id:
+ *                       type: string
+ *                     email:
+ *                       type: string
+ *                     profile:
+ *                       type: object
+ *                       properties:
+ *                         phone:
+ *                           type: string
+ *                         companyName:
+ *                           type: string
+ *                         address:
+ *                           type: string
+ *                         bio:
+ *                           type: string
+ *                         tags:
+ *                           type: array
+ *                           items:
+ *                             type: string
+ *                     type:
+ *                       type: string
+ *                       enum: [CLIENT, PROVIDER]
+ *                     isActive:
+ *                       type: boolean
+ *                     createdAt:
+ *                       type: string
+ *                       format: date-time
+ *                     updatedAt:
+ *                       type: string
+ *                       format: date-time
+ *       400:
+ *         description: Validation error (Zod, domain rules, or Mongoose constraints)
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success:
+ *                   type: boolean
+ *                   example: false
+ *                 message:
+ *                   type: string
+ *                   example: "Bio is too long (max 500 characters)"
+ *                 error:
+ *                   type: string
+ *                   example: "VALIDATION_ERROR"
+ *       401:
+ *         description: Not authenticated (missing or invalid token)
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success:
+ *                   type: boolean
+ *                   example: false
+ *                 message:
+ *                   type: string
+ *                   example: "Access denied. Token required."
+ *                 error:
+ *                   type: string
+ *                   example: "MISSING_TOKEN"
+ *       403:
+ *         description: User account is deactivated
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success:
+ *                   type: boolean
+ *                   example: false
+ *                 message:
+ *                   type: string
+ *                   example: "Cannot update deactivated user profile"
+ *                 error:
+ *                   type: string
+ *                   example: "USER_DEACTIVATED"
+ *       404:
+ *         description: User not found
+ *       500:
+ *         description: Internal server error
+ */
+router.patch('/me/profile',
+  requestSanitization,
+  authMiddleware, // Garantiza req.user.userId existe
+  validateRequest({ body: UpdateUserRequestSchema }), // Validación Zod
+  userController.updateProfile // Controller invoca use case
+);
 
 /**
  * @swagger

--- a/apps/frontend/src/components/GlobalModal.tsx
+++ b/apps/frontend/src/components/GlobalModal.tsx
@@ -72,7 +72,7 @@ export function GlobalModal() {
       }
       
       // Close modal
-      hideModal();
+      // hideModal();
     } catch (error) {
       console.error('Error in modal confirm handler:', error);
       // Don't close modal if there's an error
@@ -114,7 +114,6 @@ export function GlobalModal() {
   const getVariantStrategy = () => {
     const variant = config.variant !== "default" ? config.variant : (config.feedbackVariant !== undefined ? config.feedbackVariant : 'info');
     const strategyResult = modalVariantStrategyFactory.getStrategy(variant);
-    console.log('Using modal strategy for variant:', config, strategyResult);
     return strategyResult;
   };
 

--- a/apps/frontend/src/components/GlobalModal.tsx
+++ b/apps/frontend/src/components/GlobalModal.tsx
@@ -64,6 +64,7 @@ export function GlobalModal() {
       // Call onConfirm callback if provided
       if (config.onConfirm) {
         await config.onConfirm();
+        // callback should include the logic to close the modal
       }
       
       // Resolve promise for confirmation modals
@@ -71,8 +72,6 @@ export function GlobalModal() {
         resolver(true);
       }
       
-      // Close modal
-      // hideModal();
     } catch (error) {
       console.error('Error in modal confirm handler:', error);
       // Don't close modal if there's an error

--- a/apps/frontend/src/components/forms/wizard/WizardControls.tsx
+++ b/apps/frontend/src/components/forms/wizard/WizardControls.tsx
@@ -81,7 +81,7 @@ export const WizardControls: React.FC<WizardControlsProps> = ({
           <TimerButton
             doubleConfirmation={false}
             resetOnAction={true}
-            duration={5}
+            duration={3}
             onAction={onSubmit}
             label={submitLabel}
             timerLabel={() => timerLabel}

--- a/apps/frontend/src/components/ui/TagInput.tsx
+++ b/apps/frontend/src/components/ui/TagInput.tsx
@@ -1,0 +1,250 @@
+import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Button, Input, BodyText, Badge } from '@components/ui';
+import { Plus, X } from 'lucide-react';
+
+export interface TagInputProps {
+  /**
+   * Label text displayed above the input
+   */
+  label?: string;
+  /**
+   * Current tags array
+   */
+  value: string[];
+  /**
+   * Callback when tags change
+   */
+  onChangeValue: (tags: string[]) => void;
+  /**
+   * Maximum number of tags allowed
+   * @default 5
+   */
+  maxTags?: number;
+  /**
+   * Maximum length of each tag
+   * @default 100
+   */
+  maxTagLength?: number;
+  /**
+   * Error message to display
+   */
+  error?: string;
+  /**
+   * Placeholder text for the input
+   */
+  placeholder?: string;
+  /**
+   * Helper text displayed below the input
+   */
+  helperText?: string;
+  /**
+   * Whether the field is required
+   */
+  required?: boolean;
+  /**
+   * Whether the input is disabled
+   */
+  disabled?: boolean;
+  /**
+   * Optional className for custom styling
+   */
+  className?: string;
+}
+
+/**
+ * TagInput Component
+ * 
+ * Dynamic tag-style input for adding/removing tags.
+ * Based on RelatedPartsInput pattern with tag-specific features.
+ * 
+ * Sprint #13: Used in Profile Editing (Bio & Tags)
+ * 
+ * Features:
+ * - Auto-normalize to lowercase
+ * - Type tag → Press Enter or click "+" → Tag appears
+ * - Click X on tag → Removes tag
+ * - Shows count: "3 / 5 tags"
+ * - Prevents duplicates (case-insensitive)
+ * - Enforces max length per tag
+ * 
+ * @example
+ * ```tsx
+ * const [tags, setTags] = useState<string[]>([]);
+ * 
+ * <TagInput
+ *   label="Tags"
+ *   value={tags}
+ *   onChangeValue={setTags}
+ *   maxTags={5}
+ *   maxTagLength={100}
+ * />
+ * ```
+ */
+export const TagInput: React.FC<TagInputProps> = ({
+  label,
+  value,
+  onChangeValue,
+  maxTags = 5,
+  maxTagLength = 100,
+  error,
+  placeholder,
+  helperText,
+  required = false,
+  disabled = false,
+  className = '',
+}) => {
+  const { t } = useTranslation();
+  const [inputValue, setInputValue] = useState('');
+
+  /**
+   * Add a new tag to the list
+   * Validations: non-empty, not duplicate, not exceed max, length check
+   * Auto-normalizes to lowercase for consistency
+   */
+  const handleAddTag = () => {
+    const trimmedValue = inputValue.trim();
+    
+    // Validation: empty
+    if (!trimmedValue) {
+      return;
+    }
+
+    // Validation: max length
+    if (trimmedValue.length > maxTagLength) {
+      return;
+    }
+
+    // Normalize to lowercase for tags (consistent with backend)
+    const normalizedTag = trimmedValue.toLowerCase();
+
+    // Validation: duplicate (case-insensitive to prevent near-duplicates)
+    if (value.some(tag => tag.toLowerCase() === normalizedTag)) {
+      return;
+    }
+
+    // Validation: max limit
+    if (value.length >= maxTags) {
+      return;
+    }
+
+    // Add tag
+    onChangeValue([...value, normalizedTag]);
+    setInputValue(''); // Clear input
+  };
+
+  /**
+   * Remove a tag from the list
+   */
+  const handleRemoveTag = (index: number) => {
+    const newTags = value.filter((_, i) => i !== index);
+    onChangeValue(newTags);
+  };
+
+  /**
+   * Handle Enter key press
+   */
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      handleAddTag();
+    }
+  };
+
+  const isAtMaxCapacity = value.length >= maxTags;
+
+  return (
+    <div className={className}>
+      {/* Label */}
+      {label && (
+        <label className="block text-sm font-medium mb-2">
+          {label}
+          {required && <span className="text-destructive ml-1">*</span>}
+          {value.length > 0 && (
+            <span className="text-muted-foreground ml-2">
+              ({value.length}/{maxTags})
+            </span>
+          )}
+        </label>
+      )}
+
+      {/* Helper Text */}
+      {helperText && (
+        <BodyText size="small" className="text-muted-foreground mb-2">
+          {helperText}
+        </BodyText>
+      )}
+
+      {/* Input Row */}
+      <div className="flex gap-2 mb-2">
+        <Input
+          type="text"
+          placeholder={placeholder}
+          value={inputValue}
+          onChange={(e) => setInputValue(e.target.value)}
+          onKeyDown={handleKeyDown}
+          disabled={disabled || isAtMaxCapacity}
+          className="flex-1"
+        />
+        <Button
+          htmlType="button"
+          variant="outline"
+          className="h-10 border-primary/90"
+          onPress={handleAddTag}
+          disabled={!inputValue.trim() || isAtMaxCapacity || disabled}
+        >
+          <Plus className="w-4 h-4 mr-2" />
+          {t('common.add') || 'Add'}
+        </Button>
+      </div>
+
+      {/* Tags Display */}
+      {value.length > 0 && (
+        <div className="flex flex-wrap gap-2 p-3 bg-muted/30 rounded-md min-h-[60px]">
+          {value.map((tag, index) => (
+            <Badge
+              key={index}
+              variant="secondary"
+              className="flex items-center gap-1 pr-1"
+            >
+              <span>{tag}</span>
+              <button
+                type="button"
+                onClick={() => handleRemoveTag(index)}
+                className="
+                  ml-1 rounded-full p-0.5 
+                  hover:bg-destructive/20 
+                  transition-colors
+                "
+                aria-label={`Remove ${tag}`}
+                disabled={disabled}
+              >
+                <X className="w-3 h-3" />
+              </button>
+            </Badge>
+          ))}
+        </div>
+      )}
+
+      {/* Counter + Messages */}
+      <div className="flex items-center justify-between mt-2">
+        <BodyText size="small" className="text-muted-foreground">
+          {value.length} / {maxTags} {t('common.tags') || 'tags'}
+        </BodyText>
+        
+        {isAtMaxCapacity && (
+          <BodyText size="small" className="text-warning">
+            {t('profile.edit.validation.tagsMaxCount', { max: maxTags })}
+          </BodyText>
+        )}
+      </div>
+
+      {/* Error Message */}
+      {error && (
+        <BodyText size="small" className="text-destructive mt-1">
+          {error}
+        </BodyText>
+      )}
+    </div>
+  );
+};

--- a/apps/frontend/src/components/ui/index.ts
+++ b/apps/frontend/src/components/ui/index.ts
@@ -22,6 +22,7 @@ export {
 export { InputField } from './InputField';
 export { Select } from './Select';
 export { Textarea } from './Textarea';
+export { TagInput } from './TagInput';
 export { Checkbox } from './Checkbox';
 export { 
   TextBlock, 

--- a/apps/frontend/src/components/users/ContactCard.tsx
+++ b/apps/frontend/src/components/users/ContactCard.tsx
@@ -150,6 +150,31 @@ export const ContactCard: React.FC<ContactCardProps> = ({
         </div>
       )}
 
+      {/* Bio Section - Show for all users if present (Sprint #13 Task 10.2) */}
+      {user.profile.bio && (
+        <div className="mt-3 pt-3 border-t">
+          <BodyText size="small" className="text-muted-foreground line-clamp-2">
+            {user.profile.bio}
+          </BodyText>
+        </div>
+      )}
+
+      {/* Tags Section - Show for all users if present (Sprint #13 Task 10.2) */}
+      {user.profile.tags && user.profile.tags.length > 0 && (
+        <div className="mt-2 flex flex-wrap gap-1.5">
+          {user.profile.tags.map((tag, index) => (
+            <Badge 
+              key={index} 
+              variant="secondary" 
+              size="sm"
+              className="text-xs"
+            >
+              #{tag}
+            </Badge>
+          ))}
+        </div>
+      )}
+
       {/* Action Buttons Section (Module 2: Contact Management) */}
       <div className="mt-4 pt-3 border-t flex gap-2">
         {/* Send Message Button (Module 3: Enabled) */}

--- a/apps/frontend/src/components/users/ContactCard.tsx
+++ b/apps/frontend/src/components/users/ContactCard.tsx
@@ -169,7 +169,7 @@ export const ContactCard: React.FC<ContactCardProps> = ({
               size="sm"
               className="text-xs"
             >
-              #{tag}
+              {tag}
             </Badge>
           ))}
         </div>

--- a/apps/frontend/src/components/users/UserCard.tsx
+++ b/apps/frontend/src/components/users/UserCard.tsx
@@ -144,6 +144,31 @@ export const UserCard: React.FC<UserCardProps> = ({
         </div>
       )}
 
+
+      {/* Tags Section - Show for all users if present (Sprint #13 Task 10.2) */}
+      {user.profile.tags && user.profile.tags.length > 0 && (
+        <div className="mt-2 flex flex-wrap gap-1.5">
+          {user.profile.tags.map((tag, index) => (
+            <Badge 
+              key={index} 
+              variant="secondary" 
+              size="sm"
+              className="text-xs"
+            >
+              {tag}
+            </Badge>
+          ))}
+        </div>
+      )}
+      {/* Bio Section - Show for all users if present (Sprint #13 Task 10.2) */}
+      {user.profile.bio && (
+        <div className="mt-3 pt-3 border-t">
+          <BodyText size="small" className="text-muted-foreground line-clamp-2">
+            {user.profile.bio}
+          </BodyText>
+        </div>
+      )}
+
       {/* Interaction Section (Module 2: Contact Management) */}
       {onAddContact && (
         <div className="mt-4 pt-3 border-t">
@@ -189,6 +214,23 @@ export const UserCard: React.FC<UserCardProps> = ({
       {/* TODO Module 3+: Additional interaction buttons */}
       {/* <Button onClick={() => onMessage?.(user.id)}>Send Message</Button> */}
       {/* <Button onClick={() => onClick?.(user)}>View Profile</Button> */}
+      
+      {/* TODO: Bio Expansion Feature (Strategic Enhancement)
+       * When bio is longer than 2 lines (line-clamp-2), add "Read more" button
+       * Opens full profile modal with complete bio, all tags, service areas, etc.
+       * 
+       * @example
+       * {user.profile.bio && isBioTruncated && (
+       *   <Button 
+       *     size="sm" 
+       *     variant="ghost" 
+       *     onClick={() => onViewFullProfile?.(user)}
+       *     className="mt-1"
+       *   >
+       *     {t('users.discovery.readMore')}
+       *   </Button>
+       * )}
+       */}
       
       {/* TODO: Quick Actions Menu (Optional Enhancement)
        * Add dropdown menu with additional actions for contacts:

--- a/apps/frontend/src/i18n/locales/en.json
+++ b/apps/frontend/src/i18n/locales/en.json
@@ -50,6 +50,7 @@
     "success": "Success",
     "cancel": "Cancel",
     "save": "Save",
+    "add": "Add",
     "edit": "Edit",
     "delete": "Delete",
     "create": "Create",
@@ -87,6 +88,7 @@
     "notSpecified": "Not specified",
     "imageLoadError": "Failed to load image",
     "uses": "uses",
+    "tags": "tags",
     "retry": "Retry",
     "description": "Description",
     "expand": "Expand",
@@ -768,6 +770,76 @@
       "removing": "Removing...",
       "contactAdded": "Contact added",
       "messagingComingSoon": "Messaging coming soon"
+    }
+  },
+  "profile": {
+    "title": "My Profile",
+    "edit": {
+      "title": "Edit Profile",
+      "subtitle": "Update your personal and professional information",
+      "verificationTime": "Verify the changes!",
+      "steps": {
+        "basicInfo": {
+          "title": "Basic Information",
+          "description": "Your company contact details"
+        },
+        "bioAndTags": {
+          "title": "Bio and Tags",
+          "description": "Tell us more about your company"
+        },
+        "confirmation": {
+          "title": "Confirmation",
+          "description": "Review and confirm your changes"
+        }
+      },
+      "confirmation": {
+        "title": "Confirm your changes",
+        "subtitle": "Review all information before updating your profile",
+        "infoMessage": "By clicking \"Update Profile\", your changes will be saved. You can edit your profile again at any time.",
+        "errorsFound": "Errors were found in the information:",
+        "goBackToFix": "Please go back to previous steps to fix these errors.",
+        "modal": {
+          "title": "Update Profile",
+          "description": "Are you sure you want to update your profile with the new information?",
+          "confirmButton": "Update Profile",
+          "cancelButton": "Cancel"
+        }
+      },
+      "fields": {
+        "companyName": "Company Name",
+        "companyNamePlaceholder": "e.g., South Transport Inc.",
+        "phone": "Phone",
+        "phonePlaceholder": "+1 555 123 4567",
+        "address": "Address",
+        "addressPlaceholder": "123 Main St, City",
+        "bio": "Biography",
+        "bioPlaceholder": "Tell us about your company, services you offer, experience...",
+        "bioHelper": "A brief description of your company (max 500 characters)",
+        "tags": "Tags",
+        "tagsPlaceholder": "Type and press Enter or comma to add",
+        "tagsHelper": "Add up to 5 tags that describe your company (e.g., cranes, maintenance, transport)"
+      },
+      "success": {
+        "title": "Profile Updated",
+        "message": "Your profile has been updated successfully",
+        "description": "Changes have been saved correctly"
+      },
+      "errors": {
+        "title": "Error updating profile",
+        "update": "Could not update profile. Please try again.",
+        "noUser": "Authenticated user not found",
+        "loadUser": "Error loading user data",
+        "loadUserTitle": "Could not load your profile"
+      },
+      "validation": {
+        "maxLength": "Maximum {{max}} characters allowed",
+        "bioMaxLength": "Biography must be maximum {{max}} characters",
+        "tagsMaxCount": "Maximum {{max}} tags allowed",
+        "duplicateTags": "Duplicate tags are not allowed",
+        "invalid": "Invalid value",
+        "invalidStep": "Invalid validation step",
+        "unexpectedError": "Unexpected error during validation"
+      }
     }
   }
 }

--- a/apps/frontend/src/i18n/locales/es.json
+++ b/apps/frontend/src/i18n/locales/es.json
@@ -50,6 +50,7 @@
     "success": "Éxito",
     "cancel": "Cancelar",
     "save": "Guardar",
+    "add": "Agregar",
     "edit": "Editar",
     "delete": "Eliminar",
     "create": "Crear",
@@ -87,6 +88,7 @@
     "notSpecified": "No especificado",
     "imageLoadError": "Error al cargar la imagen",
     "uses": "usos",
+    "tags": "etiquetas",
     "retry": "Reintentar",
     "description": "Descripción",
     "expand": "Expandir",
@@ -770,6 +772,76 @@
       "removing": "Eliminando...",
       "contactAdded": "Contacto agregado",
       "messagingComingSoon": "Mensajería disponible próximamente"
+    }
+  },
+  "profile": {
+    "title": "Mi Perfil",
+    "edit": {
+      "title": "Editar Perfil",
+      "subtitle": "Actualiza tu información personal y profesional",
+      "verificationTime": "¡Verifica los cambios!",
+      "steps": {
+        "basicInfo": {
+          "title": "Información Básica",
+          "description": "Datos de contacto de tu empresa"
+        },
+        "bioAndTags": {
+          "title": "Bio y Etiquetas",
+          "description": "Cuéntanos más sobre tu empresa"
+        },
+        "confirmation": {
+          "title": "Confirmación",
+          "description": "Revisa y confirma los cambios"
+        }
+      },
+      "confirmation": {
+        "title": "Confirma los cambios",
+        "subtitle": "Revisa toda la información antes de actualizar tu perfil",
+        "infoMessage": "Al hacer clic en \"Actualizar Perfil\", se guardarán los cambios. Podrás editar tu perfil nuevamente en cualquier momento.",
+        "errorsFound": "Se encontraron errores en la información:",
+        "goBackToFix": "Por favor, regresa a los pasos anteriores para corregir estos errores.",
+        "modal": {
+          "title": "Actualizar Perfil",
+          "description": "¿Seguro de actualizar tu perfil con estos datos?",
+          "confirmButton": "Actualizar Perfil",
+          "cancelButton": "Cancelar"
+        }
+      },
+      "fields": {
+        "companyName": "Nombre de Empresa",
+        "companyNamePlaceholder": "Ej: Transportes del Sur SpA",
+        "phone": "Teléfono",
+        "phonePlaceholder": "+56 9 1234 5678",
+        "address": "Dirección",
+        "addressPlaceholder": "Av. Principal 123, Santiago",
+        "bio": "Biografía",
+        "bioPlaceholder": "Cuéntanos sobre tu empresa, servicios que ofreces, experiencia...",
+        "bioHelper": "Una breve descripción de tu empresa (máximo 500 caracteres)",
+        "tags": "Etiquetas",
+        "tagsPlaceholder": "Escribe y presiona Enter o coma para agregar",
+        "tagsHelper": "Agrega hasta 5 etiquetas que describan tu empresa (ej: grúas, mantenimiento, transporte)"
+      },
+      "success": {
+        "title": "Perfil Actualizado",
+        "message": "Tu perfil ha sido actualizado exitosamente",
+        "description": "Los cambios se han guardado correctamente"
+      },
+      "errors": {
+        "title": "Error al actualizar perfil",
+        "update": "No se pudo actualizar el perfil. Intenta nuevamente.",
+        "noUser": "No se encontró el usuario autenticado",
+        "loadUser": "Error al cargar datos del usuario",
+        "loadUserTitle": "No se pudo cargar tu perfil"
+      },
+      "validation": {
+        "maxLength": "Máximo {{max}} caracteres permitidos",
+        "bioMaxLength": "La biografía debe tener máximo {{max}} caracteres",
+        "tagsMaxCount": "Máximo {{max}} etiquetas permitidas",
+        "duplicateTags": "No se permiten etiquetas duplicadas",
+        "invalid": "Valor inválido",
+        "invalidStep": "Paso de validación inválido",
+        "unexpectedError": "Error inesperado durante la validación"
+      }
     }
   }
 }

--- a/apps/frontend/src/router/AppRouter.tsx
+++ b/apps/frontend/src/router/AppRouter.tsx
@@ -20,6 +20,7 @@ import { QuickCheckScreen } from '../screens/quickcheck/QuickCheckScreen';
 import { QuickCheckHistoryScreen } from '../screens/quickcheck/QuickCheckHistoryScreen';
 import { NotificationsScreen } from '../screens/notifications/NotificationsScreen';
 import { ProfileScreen } from '../screens/profile/ProfileScreen';
+import { EditProfileScreen } from '../screens/profile/EditProfileScreen';
 import { ConfigurationsScreen } from '../screens/settings/ConfigurationsScreen';
 import { ExamplesScreen } from '../screens/ExamplesScreen';
 import { UserDiscoveryScreen, MyContactsScreen } from '../screens/users';
@@ -78,6 +79,7 @@ export const AppRouter: React.FC = () => {
           <Route path="messages" element={<ConversationsListScreen />} />
           <Route path="messages/:otherUserId" element={<ChatScreen />} />
           <Route path="profile" element={<ProfileScreen />} />
+          <Route path="profile/edit" element={<EditProfileScreen />} />
           <Route path="settings" element={<ConfigurationsScreen />} />
 
           {/* Examples */}

--- a/apps/frontend/src/screens/profile/EditProfileScreen.tsx
+++ b/apps/frontend/src/screens/profile/EditProfileScreen.tsx
@@ -1,0 +1,125 @@
+import React from 'react';
+import { FormProvider } from 'react-hook-form';
+import { useTranslation } from 'react-i18next';
+import { Wizard } from '../../components/forms/wizard';
+import { useEditProfileViewModel } from '../../viewModels/profile/useEditProfileViewModel';
+import { modal } from '@helpers/modal';
+import { UserProfileEditData } from '../../types/user.types';
+import { Button, TextBlock, Skeleton, Card } from '@components/ui';
+import { AlertTriangle } from 'lucide-react';
+
+/**
+ * Edit Profile Screen
+ * Sprint #13 Tasks 10.1 + 10.2: User Profile Editing + Bio & Tags
+ * 
+ * Pantalla principal para edición de perfil usando wizard multi-step + React Hook Form
+ * Patrón similar a MachineRegistrationScreen
+ */
+export function EditProfileScreen() {
+  const { t } = useTranslation();
+  
+  // ViewModel maneja toda la lógica
+  const viewModel = useEditProfileViewModel();
+  const {
+    form,
+    wizardSteps,
+    forceUpdate,
+    isLoadingUserData,
+    loadUserError,
+    isSubmitting,
+    handleWizardSubmit,
+    handleCancel,
+  } = viewModel;
+
+  /**
+   * Wrapper que abre modal de confirmación antes del submit real
+   * Usa modal.show() directamente (reutiliza lógica global de modales)
+   */
+  const handleSubmitWithConfirmation = async (data: UserProfileEditData) => {
+    modal.show({
+      title: t('profile.edit.confirmation.modal.title'),
+      description: t('profile.edit.confirmation.modal.description'),
+      showConfirm: true,
+      showCancel: true,
+      confirmText: t('profile.edit.confirmation.modal.confirmButton'),
+      cancelText: t('profile.edit.confirmation.modal.cancelButton'),
+      variant: "warning",
+      onConfirm: async () => {
+        await handleWizardSubmit(data);
+      },
+    });
+  };
+
+  return (
+    <div className="max-w-4xl mx-auto p-6">
+      {/* Header */}
+      <div className="mb-8">
+        <TextBlock as="h1" size="headline">
+          {t('profile.edit.title')}
+        </TextBlock>
+        <TextBlock as="p" size="medium" className="mt-2 text-gray-600">
+          {t('profile.edit.subtitle')}
+        </TextBlock>
+      </div>
+
+      {/* Loading skeleton mientras carga datos del usuario */}
+      {isLoadingUserData && (
+        <Card className="p-6">
+          <div className="space-y-6">
+            <div className="h-8 w-1/3"><Skeleton className="h-8 w-full" /></div>
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+              <Skeleton className="h-10 w-full" />
+              <Skeleton className="h-10 w-full" />
+              <Skeleton className="h-24 w-full md:col-span-2" />
+            </div>
+            <div className="flex justify-end space-x-2">
+              <Skeleton className="h-10 w-32" />
+              <Skeleton className="h-10 w-32" />
+            </div>
+          </div>
+        </Card>
+      )}
+
+      {/* Error al cargar datos del usuario */}
+      {loadUserError && !isLoadingUserData && (
+        <Card className="mb-6 bg-yellow-50 border border-yellow-200 p-6">
+          <div className="flex items-start gap-4">
+            <AlertTriangle className="w-6 h-6 text-yellow-600 flex-shrink-0 mt-0.5" />
+            <div className="flex-1">
+              <h3 className="text-sm font-medium text-yellow-800 mb-1">
+                {t('profile.edit.errors.loadUserTitle')}
+              </h3>
+              <p className="text-sm text-yellow-700 mb-3">
+                {loadUserError}
+              </p>
+              <Button 
+                onPress={handleCancel}
+                variant="outline"
+                size="sm"
+              >
+                {t('common.back')}
+              </Button>
+            </div>
+          </div>
+        </Card>
+      )}
+
+      {/* Wizard Form */}
+      {!isLoadingUserData && !loadUserError && (
+        <FormProvider {...form}>
+          <Wizard<UserProfileEditData>
+            steps={wizardSteps}
+            initialData={form.getValues()}
+            onSubmit={handleSubmitWithConfirmation}
+            onStepChange={forceUpdate}
+            isSubmitting={isSubmitting}
+            onCancel={handleCancel}
+            timerLabel={t('profile.edit.verificationTime')}
+            className="bg-white shadow-lg rounded-lg"
+            showProgress
+          />
+        </FormProvider>
+      )}
+    </div>
+  );
+}

--- a/apps/frontend/src/screens/profile/ProfileScreen.tsx
+++ b/apps/frontend/src/screens/profile/ProfileScreen.tsx
@@ -1,8 +1,33 @@
 import React from 'react';
-import { Heading1, Heading2, BodyText, Button, Card } from '@components/ui';
-import { User, Mail, Phone, Calendar, Shield, Edit } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
+import { useAuth } from '../../store/AuthProvider';
+import { Heading1, Heading2, BodyText, Button, Card, Badge, Skeleton } from '@components/ui';
+import { User, Mail, Phone, Calendar, Shield, Edit, Building2, MapPin, Tag } from 'lucide-react';
 
 export const ProfileScreen: React.FC = () => {
+  const navigate = useNavigate();
+  const { user, isLoading } = useAuth();
+
+  // Loading state
+  if (isLoading || !user) {
+    return (
+      <div className="space-y-8">
+        <Skeleton className="h-12 w-64" />
+        <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+          <Skeleton className="h-96" />
+          <div className="lg:col-span-2 space-y-6">
+            <Skeleton className="h-48" />
+            <Skeleton className="h-48" />
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  const handleEditProfile = () => {
+    navigate('/profile/edit');
+  };
+
   return (
     <div className="space-y-8">
       <div className="flex justify-between items-center">
@@ -14,7 +39,7 @@ export const ProfileScreen: React.FC = () => {
             Gestiona tu información personal y preferencias de cuenta
           </BodyText>
         </div>
-        <Button variant="filled" size="default">
+        <Button variant="filled" size="default" onPress={handleEditProfile}>
           <Edit className="w-4 h-4 mr-2" />
           Editar Perfil
         </Button>
@@ -30,20 +55,25 @@ export const ProfileScreen: React.FC = () => {
               </div>
               <div>
                 <Heading2 size="large" weight="bold" className="text-foreground">
-                  Usuario Demo
+                  {user.profile?.companyName || 'Sin nombre de empresa'}
                 </Heading2>
                 <BodyText size="small" className="text-muted-foreground">
-                  Administrador de Flota
+                  {user.type === 'CLIENT' ? 'Cliente' : 'Proveedor de Servicios'}
                 </BodyText>
               </div>
               <div className="w-full pt-4 border-t border-border space-y-2">
                 <div className="flex items-center justify-center gap-2 text-muted-foreground">
                   <Shield className="w-4 h-4" />
-                  <BodyText size="small">Cuenta Verificada</BodyText>
+                  <BodyText size="small">Cuenta Activa</BodyText>
                 </div>
                 <div className="flex items-center justify-center gap-2 text-muted-foreground">
                   <Calendar className="w-4 h-4" />
-                  <BodyText size="small">Miembro desde Ene 2024</BodyText>
+                  <BodyText size="small">
+                    Miembro desde {new Date(user.createdAt).toLocaleDateString('es-ES', { 
+                      month: 'short', 
+                      year: 'numeric' 
+                    })}
+                  </BodyText>
                 </div>
               </div>
             </div>
@@ -52,49 +82,6 @@ export const ProfileScreen: React.FC = () => {
 
         {/* Information Cards */}
         <div className="lg:col-span-2 space-y-6">
-          {/* Personal Information */}
-          <Card>
-            <div className="p-6">
-              <Heading2 size="large" weight="bold" className="mb-4">
-                Información Personal
-              </Heading2>
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                <div className="space-y-2">
-                  <BodyText size="small" weight="medium" className="text-muted-foreground">
-                    Nombre Completo
-                  </BodyText>
-                  <BodyText className="text-foreground">
-                    Usuario Demo
-                  </BodyText>
-                </div>
-                <div className="space-y-2">
-                  <BodyText size="small" weight="medium" className="text-muted-foreground">
-                    RUT
-                  </BodyText>
-                  <BodyText className="text-foreground">
-                    12.345.678-9
-                  </BodyText>
-                </div>
-                <div className="space-y-2">
-                  <BodyText size="small" weight="medium" className="text-muted-foreground">
-                    Cargo
-                  </BodyText>
-                  <BodyText className="text-foreground">
-                    Administrador de Flota
-                  </BodyText>
-                </div>
-                <div className="space-y-2">
-                  <BodyText size="small" weight="medium" className="text-muted-foreground">
-                    Departamento
-                  </BodyText>
-                  <BodyText className="text-foreground">
-                    Operaciones
-                  </BodyText>
-                </div>
-              </div>
-            </div>
-          </Card>
-
           {/* Contact Information */}
           <Card>
             <div className="p-6">
@@ -111,69 +98,96 @@ export const ProfileScreen: React.FC = () => {
                       Email
                     </BodyText>
                     <BodyText weight="medium" className="text-foreground">
-                      usuario.demo@fleetman.cl
+                      {user.email}
                     </BodyText>
                   </div>
                 </div>
-                <div className="flex items-center gap-3">
-                  <div className="w-10 h-10 rounded-lg bg-primary/10 flex items-center justify-center">
-                    <Phone className="w-5 h-5 text-primary" />
+                
+                {user.profile?.phone && (
+                  <div className="flex items-center gap-3">
+                    <div className="w-10 h-10 rounded-lg bg-primary/10 flex items-center justify-center">
+                      <Phone className="w-5 h-5 text-primary" />
+                    </div>
+                    <div>
+                      <BodyText size="small" className="text-muted-foreground">
+                        Teléfono
+                      </BodyText>
+                      <BodyText weight="medium" className="text-foreground">
+                        {user.profile.phone}
+                      </BodyText>
+                    </div>
                   </div>
-                  <div>
-                    <BodyText size="small" className="text-muted-foreground">
-                      Teléfono
-                    </BodyText>
-                    <BodyText weight="medium" className="text-foreground">
-                      +56 9 1234 5678
-                    </BodyText>
+                )}
+
+                {user.profile?.companyName && (
+                  <div className="flex items-center gap-3">
+                    <div className="w-10 h-10 rounded-lg bg-primary/10 flex items-center justify-center">
+                      <Building2 className="w-5 h-5 text-primary" />
+                    </div>
+                    <div>
+                      <BodyText size="small" className="text-muted-foreground">
+                        Empresa
+                      </BodyText>
+                      <BodyText weight="medium" className="text-foreground">
+                        {user.profile.companyName}
+                      </BodyText>
+                    </div>
                   </div>
-                </div>
+                )}
+
+                {user.profile?.address && (
+                  <div className="flex items-center gap-3">
+                    <div className="w-10 h-10 rounded-lg bg-primary/10 flex items-center justify-center">
+                      <MapPin className="w-5 h-5 text-primary" />
+                    </div>
+                    <div>
+                      <BodyText size="small" className="text-muted-foreground">
+                        Dirección
+                      </BodyText>
+                      <BodyText weight="medium" className="text-foreground">
+                        {user.profile.address}
+                      </BodyText>
+                    </div>
+                  </div>
+                )}
               </div>
             </div>
           </Card>
 
-          {/* Account Stats */}
-          <Card>
-            <div className="p-6">
-              <Heading2 size="large" weight="bold" className="mb-4">
-                Estadísticas de Cuenta
-              </Heading2>
-              <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-                <div className="text-center p-4 bg-muted/30 rounded-lg">
-                  <Heading2 size="large" weight="bold" className="text-primary">
-                    12
+          {/* Bio Section - NEW Sprint #13 */}
+          {user.profile?.bio && (
+            <Card>
+              <div className="p-6">
+                <Heading2 size="large" weight="bold" className="mb-3">
+                  Biografía
+                </Heading2>
+                <BodyText className="text-foreground whitespace-pre-wrap">
+                  {user.profile.bio}
+                </BodyText>
+              </div>
+            </Card>
+          )}
+
+          {/* Tags Section - NEW Sprint #13 */}
+          {user.profile?.tags && user.profile.tags.length > 0 && (
+            <Card>
+              <div className="p-6">
+                <div className="flex items-center gap-2 mb-3">
+                  <Tag className="w-5 h-5 text-primary" />
+                  <Heading2 size="large" weight="bold">
+                    Etiquetas
                   </Heading2>
-                  <BodyText size="small" className="text-muted-foreground">
-                    Máquinas
-                  </BodyText>
                 </div>
-                <div className="text-center p-4 bg-muted/30 rounded-lg">
-                  <Heading2 size="large" weight="bold" className="text-primary">
-                    48
-                  </Heading2>
-                  <BodyText size="small" className="text-muted-foreground">
-                    QuickChecks
-                  </BodyText>
-                </div>
-                <div className="text-center p-4 bg-muted/30 rounded-lg">
-                  <Heading2 size="large" weight="bold" className="text-primary">
-                    156
-                  </Heading2>
-                  <BodyText size="small" className="text-muted-foreground">
-                    Horas
-                  </BodyText>
-                </div>
-                <div className="text-center p-4 bg-muted/30 rounded-lg">
-                  <Heading2 size="large" weight="bold" className="text-primary">
-                    5
-                  </Heading2>
-                  <BodyText size="small" className="text-muted-foreground">
-                    Eventos
-                  </BodyText>
+                <div className="flex flex-wrap gap-2">
+                  {user.profile.tags.map((tag, index) => (
+                    <Badge key={index} variant="secondary" className="text-sm">
+                      {tag}
+                    </Badge>
+                  ))}
                 </div>
               </div>
-            </div>
-          </Card>
+            </Card>
+          )}
         </div>
       </div>
 

--- a/apps/frontend/src/screens/profile/edit-profile-steps/BasicInfoStep.tsx
+++ b/apps/frontend/src/screens/profile/edit-profile-steps/BasicInfoStep.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import { useFormContext, Controller } from 'react-hook-form';
+import { useTranslation } from 'react-i18next';
+import { InputField, Textarea } from '@components/ui';
+import type { UserProfileEditData } from '../../../types/user.types';
+
+/**
+ * Step 1: Basic Info Step
+ * Sprint #13 Task 10.1c: User Profile Editing - Frontend UI
+ * 
+ * Campos editables:
+ * - Nombre de empresa (opcional)
+ * - Teléfono (opcional)
+ * - Dirección (opcional)
+ */
+export const BasicInfoStep: React.FC = () => {
+  const { t } = useTranslation();
+  const { control, formState: { errors } } = useFormContext<UserProfileEditData>();
+
+  return (
+    <div className="space-y-6">
+      <div className="space-y-4">
+        {/* Company Name */}
+        <Controller
+          name="basicInfo.companyName"
+          control={control}
+          render={({ field }) => (
+            <InputField
+              label={t('profile.edit.fields.companyName')}
+              placeholder={t('profile.edit.fields.companyNamePlaceholder')}
+              error={errors.basicInfo?.companyName?.message}
+              {...field}
+            />
+          )}
+        />
+
+        {/* Phone */}
+        <Controller
+          name="basicInfo.phone"
+          control={control}
+          render={({ field }) => (
+            <InputField
+              label={t('profile.edit.fields.phone')}
+              placeholder={t('profile.edit.fields.phonePlaceholder')}
+              type="tel"
+              error={errors.basicInfo?.phone?.message}
+              {...field}
+            />
+          )}
+        />
+
+        {/* Address */}
+        <Controller
+          name="basicInfo.address"
+          control={control}
+          render={({ field }) => (
+            <Textarea
+              label={t('profile.edit.fields.address')}
+              placeholder={t('profile.edit.fields.addressPlaceholder')}
+              error={errors.basicInfo?.address?.message}
+              maxLength={200}
+              showCharacterCount
+              value={field.value}
+              onChangeText={field.onChange}
+            />
+          )}
+        />
+      </div>
+    </div>
+  );
+};

--- a/apps/frontend/src/screens/profile/edit-profile-steps/BioAndTagsStep.tsx
+++ b/apps/frontend/src/screens/profile/edit-profile-steps/BioAndTagsStep.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import { useFormContext, Controller } from 'react-hook-form';
+import { useTranslation } from 'react-i18next';
+import { Textarea, TagInput } from '@components/ui';
+import type { UserProfileEditData } from '../../../types/user.types';
+import { USER_PROFILE_LIMITS } from '@contracts';
+
+/**
+ * Step 2: Bio and Tags Step
+ * Sprint #13 Task 10.2c: Bio & Tags - Frontend UI
+ * 
+ * Campos editables:
+ * - Biografía (textarea con contador, max 500 chars)
+ * - Etiquetas/Tags (chips, max 5 tags de max 100 chars cada uno)
+ */
+export const BioAndTagsStep: React.FC = () => {
+  const { t } = useTranslation();
+  const { control, formState: { errors } } = useFormContext<UserProfileEditData>();
+
+  return (
+    <div className="space-y-6">
+      <div className="space-y-4">
+        {/* Bio */}
+        <Controller
+          name="bioAndTags.bio"
+          control={control}
+          render={({ field: { onChange, onBlur, value } }) => (
+            <Textarea
+              label={t('profile.edit.fields.bio')}
+              placeholder={t('profile.edit.fields.bioPlaceholder')}
+              helperText={t('profile.edit.fields.bioHelper')}
+              value={value || ''}
+              onChangeText={onChange}
+              onBlur={onBlur}
+              error={errors.bioAndTags?.bio?.message}
+              maxLength={USER_PROFILE_LIMITS.MAX_BIO_LENGTH}
+              showCharacterCount
+            />
+          )}
+        />
+
+        {/* Tags */}
+        <Controller
+          name="bioAndTags.tags"
+          control={control}
+          render={({ field }) => (
+            <TagInput
+              label={t('profile.edit.fields.tags')}
+              placeholder={t('profile.edit.fields.tagsPlaceholder')}
+              helperText={t('profile.edit.fields.tagsHelper')}
+              value={field.value || []}
+              onChangeValue={field.onChange}
+              maxTags={USER_PROFILE_LIMITS.MAX_TAGS}
+              maxTagLength={USER_PROFILE_LIMITS.MAX_TAG_LENGTH}
+              error={errors.bioAndTags?.tags?.message}
+            />
+          )}
+        />
+      </div>
+    </div>
+  );
+};

--- a/apps/frontend/src/screens/profile/edit-profile-steps/ProfileConfirmationStep.tsx
+++ b/apps/frontend/src/screens/profile/edit-profile-steps/ProfileConfirmationStep.tsx
@@ -1,0 +1,156 @@
+import React from 'react';
+import { useFormContext, useWatch } from 'react-hook-form';
+import { useTranslation } from 'react-i18next';
+import { Card, CardContent, CardHeader, CardTitle } from '@components/ui';
+import { UserProfileEditData } from '../../../types/user.types';
+
+/**
+ * Paso 3: Confirmación y resumen de la información del perfil
+ * Componente de solo lectura que muestra un resumen de todos los cambios antes de guardar
+ */
+export function ProfileConfirmationStep() {
+  const { 
+    control, 
+    formState: { errors }
+  } = useFormContext<UserProfileEditData>();
+  
+  const { t } = useTranslation();
+  
+  // Watch all form values for real-time updates
+  const data = useWatch({ control });
+  const { basicInfo, bioAndTags } = data;
+
+  // Helper para mostrar valores con fallback
+  const displayValue = (value: any, fallback?: string) => {
+    return value ?? (fallback || t('common.notSpecified'));
+  };
+
+  return (
+    <div className="space-y-6">
+      <div className="text-center mb-8">
+        <h2 className="text-2xl font-bold text-foreground mb-2">
+          {t('profile.edit.confirmation.title')}
+        </h2>
+        <p className="text-muted-foreground">
+          {t('profile.edit.confirmation.subtitle')}
+        </p>
+      </div>
+
+      {/* Información básica */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center space-x-2">
+            <div className="w-8 h-8 bg-info/10 rounded-full flex items-center justify-center">
+              <span className="text-info font-semibold">1</span>
+            </div>
+            <span>{t('profile.edit.steps.basicInfo.title')}</span>
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div>
+              <dt className="text-sm font-medium text-muted-foreground">
+                {t('profile.edit.fields.companyName')}
+              </dt>
+              <dd className="text-sm text-foreground">
+                {displayValue(basicInfo?.companyName)}
+              </dd>
+            </div>
+            <div>
+              <dt className="text-sm font-medium text-muted-foreground">
+                {t('profile.edit.fields.phone')}
+              </dt>
+              <dd className="text-sm text-foreground">
+                {displayValue(basicInfo?.phone)}
+              </dd>
+            </div>
+            {basicInfo?.address && (
+              <div className="md:col-span-2">
+                <dt className="text-sm font-medium text-muted-foreground">
+                  {t('profile.edit.fields.address')}
+                </dt>
+                <dd className="text-sm text-foreground">{basicInfo.address}</dd>
+              </div>
+            )}
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Bio y Tags */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center space-x-2">
+            <div className="w-8 h-8 bg-success/10 rounded-full flex items-center justify-center">
+              <span className="text-success font-semibold">2</span>
+            </div>
+            <span>{t('profile.edit.steps.bioAndTags.title')}</span>
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {bioAndTags?.bio && (
+            <div>
+              <dt className="text-sm font-medium text-muted-foreground">
+                {t('profile.edit.fields.bio')}
+              </dt>
+              <dd className="text-sm text-foreground whitespace-pre-wrap">{bioAndTags.bio}</dd>
+            </div>
+          )}
+          {bioAndTags?.tags && bioAndTags.tags.length > 0 && (
+            <div>
+              <dt className="text-sm font-medium text-muted-foreground">
+                {t('profile.edit.fields.tags')}
+              </dt>
+              <dd className="text-sm text-foreground">
+                <div className="flex flex-wrap gap-2 mt-1">
+                  {bioAndTags.tags.map((tag, index) => (
+                    <span
+                      key={index}
+                      className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-primary/10 text-primary"
+                    >
+                      {tag}
+                    </span>
+                  ))}
+                </div>
+              </dd>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Errores globales */}
+      {errors && Object.keys(errors).length > 0 && (
+        <div className="bg-destructive/10 border border-destructive/20 rounded-md p-4">
+          <h4 className="text-destructive font-medium mb-2">
+            {t('profile.edit.confirmation.errorsFound')}
+          </h4>
+          <ul className="list-disc list-inside space-y-1">
+            {Object.entries(errors).map(([field, error]) => (
+              <li key={field} className="text-destructive text-sm">
+                {field}: {error?.message || t('common.validationError')}
+              </li>
+            ))}
+          </ul>
+          <p className="text-destructive text-sm mt-2">
+            {t('profile.edit.confirmation.goBackToFix')}
+          </p>
+        </div>
+      )}
+
+      {/* Mensaje final */}
+      <div className="bg-info/10 p-4 rounded-md">
+        <div className="flex">
+          <div className="flex-shrink-0">
+            <svg className="h-5 w-5 text-info" viewBox="0 0 20 20" fill="currentColor">
+              <path fillRule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clipRule="evenodd" />
+            </svg>
+          </div>
+          <div className="ml-3">
+            <p className="text-sm text-info">
+              {t('profile.edit.confirmation.infoMessage')}
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/screens/profile/edit-profile-steps/index.ts
+++ b/apps/frontend/src/screens/profile/edit-profile-steps/index.ts
@@ -1,0 +1,3 @@
+export { BasicInfoStep } from './BasicInfoStep';
+export { BioAndTagsStep } from './BioAndTagsStep';
+export { ProfileConfirmationStep } from './ProfileConfirmationStep';

--- a/apps/frontend/src/screens/users/MyContactsScreen.tsx
+++ b/apps/frontend/src/screens/users/MyContactsScreen.tsx
@@ -170,8 +170,8 @@ export function MyContactsScreen() {
           </BodyText>
         </div>
 
-        {/* Contacts List (vertical layout) */}
-        <div className="flex flex-col gap-3">
+        {/* Contacts List (responsive grid: 1 col mobile, 2 cols desktop) */}
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
           {vm.data.contacts.map((contact) => (
             <ContactCard
               key={contact.id}

--- a/apps/frontend/src/screens/users/UserDiscoveryScreen.tsx
+++ b/apps/frontend/src/screens/users/UserDiscoveryScreen.tsx
@@ -159,8 +159,20 @@ export function UserDiscoveryScreen() {
           )}
         </div>
 
-        {/* Users List (vertical layout per WBS 9.1c spec) */}
-        <div className="flex flex-col gap-3">
+        {/* Users List (responsive grid: 1 col mobile, 2 cols desktop) */}
+        {/* TODO: Enhance responsiveness for ultra-wide screens
+         * Current: grid-cols-1 md:grid-cols-2 (1 column mobile, 2 desktop)
+         * Enhancement: Add xl:grid-cols-3 for 3 columns on extra large screens (≥1280px)
+         * 
+         * @example
+         * <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-3">
+         * 
+         * Benefits:
+         * - Better space utilization on large monitors
+         * - More contacts visible without scrolling
+         * - Maintains readability (cards don't get too wide)
+         */}
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
           {vm.data.users.map((user) => {
             // O(1) lookup: Check if user is already a contact using Set
             // Fixes Rules of Hooks violation (was calling hook inside loop)

--- a/apps/frontend/src/services/api/userService.ts
+++ b/apps/frontend/src/services/api/userService.ts
@@ -1,0 +1,93 @@
+import { apiClient, handleApiResponse } from './apiClient';
+import type { UpdateUserRequest, UpdateUserResponse } from '@contracts';
+
+/**
+ * User Service
+ * Sprint #13 Tasks 10.1 + 10.2: User Profile Editing + Bio & Tags
+ * 
+ * Handles API calls related to user profile management
+ */
+export class UserService {
+  /**
+   * Updates the authenticated user's profile
+   * PATCH /api/users/me/profile
+   * 
+   * @param data - Profile update data (phone, companyName, address, bio, tags)
+   * @returns Updated user data
+   */
+  async updateMyProfile(data: UpdateUserRequest): Promise<UpdateUserResponse> {
+    const response = await apiClient.patch<{ 
+      success: boolean; 
+      message?: string; 
+      data: UpdateUserResponse 
+    }>(
+      '/users/me/profile',
+      data
+    );
+    
+    const processed = handleApiResponse(response);
+    // Extract data from wrapped response
+    return (processed as any).data ?? (processed as any);
+  }
+
+  // TODO: Future endpoints (Sprint #13+)
+  /**
+   * Gets the authenticated user's complete profile
+   * GET /api/users/me/profile
+   */
+  // async getMyProfile(): Promise<GetUserResponse> {
+  //   const response = await apiClient.get<{ success: boolean; data: GetUserResponse }>(
+  //     '/users/me/profile'
+  //   );
+  //   const processed = handleApiResponse(response);
+  //   return (processed as any).data ?? (processed as any);
+  // }
+
+  /**
+   * Gets a user's public profile (for User Discovery)
+   * GET /api/users/:userId/public
+   */
+  // async getUserPublicProfile(userId: string): Promise<UserPublicProfile> {
+  //   const response = await apiClient.get<{ success: boolean; data: UserPublicProfile }>(
+  //     `/users/${userId}/public`
+  //   );
+  //   const processed = handleApiResponse(response);
+  //   return (processed as any).data ?? (processed as any);
+  // }
+
+  /**
+   * Uploads user avatar image
+   * POST /api/users/me/avatar
+   * Task 10.3: Image Upload Component
+   */
+  // async uploadAvatar(file: File): Promise<{ avatarUrl: string }> {
+  //   const formData = new FormData();
+  //   formData.append('avatar', file);
+  //   
+  //   const response = await apiClient.post<{ success: boolean; data: { avatarUrl: string } }>(
+  //     '/users/me/avatar',
+  //     formData,
+  //     { headers: { 'Content-Type': 'multipart/form-data' } }
+  //   );
+  //   const processed = handleApiResponse(response);
+  //   return (processed as any).data ?? (processed as any);
+  // }
+
+  /**
+   * Gets tag suggestions based on popularity
+   * GET /api/tags/suggestions
+   * Task 10.2b: Optional autocomplete for tags
+   */
+  // async getTagSuggestions(query?: string): Promise<string[]> {
+  //   const params = query ? { query } : {};
+  //   const response = await apiClient.get<{ success: boolean; data: string[] }>(
+  //     '/tags/suggestions',
+  //     params
+  //   );
+  //   const processed = handleApiResponse(response);
+  //   return (processed as any).data ?? (processed as any);
+  // }
+}
+
+// Export singleton instance
+export const userService = new UserService();

--- a/apps/frontend/src/store/slices/authSlice.ts
+++ b/apps/frontend/src/store/slices/authSlice.ts
@@ -28,6 +28,7 @@ interface AuthStore extends AuthState {
   clearError: () => void;
   setHydrated: (isHydrated: boolean) => void;
   markSessionExpired: () => void; // Mark session as expired (prevent duplicate modals)
+  updateUserProfile: (updatedUser: User) => void; // 🆕 Sprint #13 Task 10.1: Update user profile in store
 }
 
 export const useAuthStore = create<AuthStore>()(
@@ -251,6 +252,32 @@ export const useAuthStore = create<AuthStore>()(
 
       markSessionExpired: () => {
         set({ isSessionExpiredModalShown: true });
+      },
+
+      /**
+       * Updates user profile in store after successful edit
+       * Sprint #13 Task 10.1: User Profile Editing
+       * 
+       * @param updatedUser - Updated user data from API response
+       */
+      updateUserProfile: (updatedUser: User) => {
+        set((state) => ({
+          user: {
+            ...state.user,
+            ...updatedUser,
+            // Ensure we merge the profile object properly
+            profile: {
+              ...state.user?.profile,
+              ...updatedUser.profile,
+            },
+          },
+        }));
+        console.log('✅ User profile updated in AuthStore:', {
+          userId: updatedUser.id,
+          hasProfile: !!updatedUser.profile,
+          hasBio: !!updatedUser.profile?.bio,
+          tagsCount: updatedUser.profile?.tags?.length || 0,
+        });
       },
 
       // TODO: Future enhancement - Auto-refresh token before expiration

--- a/apps/frontend/src/types/user.types.ts
+++ b/apps/frontend/src/types/user.types.ts
@@ -1,0 +1,272 @@
+import { z } from 'zod';
+import { 
+  USER_PROFILE_LIMITS, 
+  UserProfileSchema,
+  type UpdateUserRequest 
+} from '@contracts';
+
+/**
+ * User Profile Types
+ * Sprint #13 Tasks 10.1 + 10.2: User Profile Editing + Bio & Tags
+ * SSOT: Uses validation schemas from @contracts, no duplication
+ */
+
+/**
+ * Form data structure for profile editing wizard
+ * UI-specific: Separado en steps para mejor UX y validación granular
+ */
+export interface UserProfileEditData {
+  basicInfo: {
+    companyName?: string;
+    phone?: string;
+    address?: string;
+  };
+  bioAndTags: {
+    bio?: string;
+    tags?: string[];
+  };
+}
+
+/**
+ * Step 1 Validation Schema: Basic Info
+ * SSOT: Composed from UserProfileSchema (contracts)
+ * Picks only fields relevant to basicInfo step
+ */
+const BasicInfoStepSchema = UserProfileSchema.pick({
+  companyName: true,
+  phone: true,
+  address: true,
+}).partial().transform((data) => ({
+  // Transform empty strings to undefined for proper optional handling
+  companyName: data.companyName?.trim() || undefined,
+  phone: data.phone?.trim() || undefined,
+  address: data.address?.trim() || undefined,
+}));
+
+/**
+ * Step 2 Validation Schema: Bio and Tags
+ * SSOT: Composed from UserProfileSchema (contracts)
+ * Picks only bio and tags fields
+ */
+const BioAndTagsStepSchema = UserProfileSchema.pick({
+  bio: true,
+  tags: true,
+}).partial().transform((data) => ({
+  // Transform empty strings to undefined
+  bio: data.bio?.trim() || undefined,
+  tags: data.tags && data.tags.length > 0 ? data.tags : undefined,
+}));
+
+/**
+ * Complete wizard validation schema
+ * SSOT: Composes step schemas from contracts UserProfileSchema
+ * Maintains wizard structure but delegates validation to SSOT
+ */
+export const UserProfileEditSchema = z.object({
+  basicInfo: z.object({
+    companyName: z.string().optional().or(z.literal('')),
+    phone: z.string().optional().or(z.literal('')),
+    address: z.string().optional().or(z.literal('')),
+  }),
+  bioAndTags: z.object({
+    bio: z.string().optional().or(z.literal('')),
+    tags: z.array(z.string()).optional().default([]),
+  }),
+});
+
+/**
+ * Default/empty values for form initialization
+ */
+export const defaultUserProfileEditData: UserProfileEditData = {
+  basicInfo: {
+    companyName: '',
+    phone: '',
+    address: '',
+  },
+  bioAndTags: {
+    bio: '',
+    tags: [],
+  },
+};
+
+/**
+ * Validation function for individual wizard steps
+ * SSOT: Uses UserProfileSchema from contracts for validation
+ * Flattens nested wizard structure → validates with contracts schema → returns result
+ * 
+ * @param step - Step name to validate
+ * @param data - Complete wizard data
+ * @returns true if step is valid, false otherwise
+ */
+export function validateProfileStep(
+  step: 'basicInfo' | 'bioAndTags',
+  data: UserProfileEditData
+): boolean {
+  try {
+    switch (step) {
+      case 'basicInfo': {
+        // Validate using contracts schema for basic info fields
+        const result = BasicInfoStepSchema.safeParse(data.basicInfo);
+        return result.success;
+      }
+      case 'bioAndTags': {
+        // Validate using contracts schema for bio and tags
+        const result = BioAndTagsStepSchema.safeParse(data.bioAndTags);
+        return result.success;
+      }
+      default:
+        return false;
+    }
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Maps wizard form data to UpdateUserRequest format
+ * Transforms UI format → API format
+ * 
+ * @param formData - Data from wizard form
+ * @param userId - User ID for the request
+ * @returns Data in UpdateUserRequest format for API call
+ */
+export function mapEditDataToUpdateRequest(
+  formData: UserProfileEditData,
+  userId: string
+): UpdateUserRequest {
+  // Convert empty strings to undefined for optional fields
+  const companyName = formData.basicInfo.companyName?.trim() || undefined;
+  const phone = formData.basicInfo.phone?.trim() || undefined;
+  const address = formData.basicInfo.address?.trim() || undefined;
+  const bio = formData.bioAndTags.bio?.trim() || undefined;
+  const tags = formData.bioAndTags.tags?.length ? formData.bioAndTags.tags : undefined;
+
+  return {
+    id: userId,
+    profile: {
+      companyName,
+      phone,
+      address,
+      bio,
+      tags,
+    },
+  };
+}
+
+/**
+ * Maps API user data to wizard form format
+ * Transforms API format → UI format
+ * Used for pre-populating the form with current user data
+ * 
+ * @param user - User data from API/AuthStore
+ * @returns Data in UserProfileEditData format for form initialization
+ */
+export function mapUserDataToEditForm(user: {
+  id: string;
+  profile?: {
+    companyName?: string;
+    phone?: string;
+    address?: string;
+    bio?: string;
+    tags?: string[];
+  };
+}): UserProfileEditData {
+  return {
+    basicInfo: {
+      companyName: user.profile?.companyName || '',
+      phone: user.profile?.phone || '',
+      address: user.profile?.address || '',
+    },
+    bioAndTags: {
+      bio: user.profile?.bio || '',
+      tags: user.profile?.tags || [],
+    },
+  };
+}
+
+/**
+ * Helper para validar y obtener errores traducidos de Zod
+ * Específico para el flujo de edición de perfil
+ * Mapea errores de validación Zod a keys de i18n
+ * 
+ * @param step - Step del wizard a validar
+ * @param data - Datos a validar
+ * @param t - Función de traducción i18n
+ * @returns { valid: boolean, errors: Record<string, string> } - Resultado y errores traducidos
+ * 
+ * @example
+ * const { valid, errors } = validateProfileStepWithErrors('basicInfo', data, t);
+ * if (!valid) {
+ *   console.error(errors); // { companyName: "El nombre debe tener máximo 100 caracteres" }
+ * }
+ */
+export function validateProfileStepWithErrors(
+  step: 'basicInfo' | 'bioAndTags',
+  data: UserProfileEditData,
+  t: (key: string, options?: Record<string, unknown>) => string
+): { valid: boolean; errors: Record<string, string> } {
+  const errors: Record<string, string> = {};
+
+  try {
+    switch (step) {
+      case 'basicInfo': {
+        const result = BasicInfoStepSchema.safeParse(data.basicInfo);
+        if (!result.success) {
+          result.error.issues.forEach((issue) => {
+            const field = issue.path[0] as string;
+            // Map Zod error codes to i18n keys
+            if (issue.code === 'too_big' && issue.type === 'string') {
+              errors[field] = t('profile.edit.validation.maxLength', { 
+                max: issue.maximum 
+              });
+            } else {
+              errors[field] = t('profile.edit.validation.invalid');
+            }
+          });
+          return { valid: false, errors };
+        }
+        return { valid: true, errors: {} };
+      }
+      case 'bioAndTags': {
+        const result = BioAndTagsStepSchema.safeParse(data.bioAndTags);
+        if (!result.success) {
+          result.error.issues.forEach((issue) => {
+            const field = issue.path[0] as string;
+            if (issue.code === 'too_big') {
+              if (field === 'bio') {
+                errors[field] = t('profile.edit.validation.bioMaxLength', {
+                  max: USER_PROFILE_LIMITS.MAX_BIO_LENGTH
+                });
+              } else if (field === 'tags') {
+                errors[field] = t('profile.edit.validation.tagsMaxCount', {
+                  max: USER_PROFILE_LIMITS.MAX_TAGS
+                });
+              }
+            } else if (issue.code === 'custom' && issue.message?.includes('Duplicate')) {
+              errors[field] = t('profile.edit.validation.duplicateTags');
+            } else {
+              errors[field] = t('profile.edit.validation.invalid');
+            }
+          });
+          return { valid: false, errors };
+        }
+        return { valid: true, errors: {} };
+      }
+      default:
+        return { valid: false, errors: { general: t('profile.edit.validation.invalidStep') } };
+    }
+  } catch (error) {
+    console.error('Error validating profile step:', error);
+    return { valid: false, errors: { general: t('profile.edit.validation.unexpectedError') } };
+  }
+}
+
+// Future enhancement: Validation for complete profile update (all fields at once)
+// export function validateCompleteProfile(data: UserProfileEditData): boolean {
+//   const flatProfile = {
+//     ...data.basicInfo,
+//     ...data.bioAndTags,
+//   };
+//   const result = UserProfileSchema.safeParse(flatProfile);
+//   return result.success;
+// }

--- a/apps/frontend/src/viewModels/profile/useEditProfileViewModel.ts
+++ b/apps/frontend/src/viewModels/profile/useEditProfileViewModel.ts
@@ -1,0 +1,263 @@
+import { useState, useCallback, useEffect, useReducer } from "react";
+import { UseFormReturn } from "react-hook-form";
+import { useTranslation } from "react-i18next";
+import { useNavigate } from "react-router-dom";
+import { WizardStep } from "../../components/forms/wizard";
+import { useZodForm } from "../../hooks/useZodForm";
+import { useAuth } from "../../store/AuthProvider";
+import { useAuthStore } from "../../store/slices/authSlice";
+import { userService } from "../../services/api/userService";
+import { toast } from "@components/ui";
+import { modal } from "@helpers/modal";
+import {
+  BasicInfoStep,
+  BioAndTagsStep,
+  ProfileConfirmationStep,
+} from "../../screens/profile/edit-profile-steps";
+import {
+  UserProfileEditData,
+  UserProfileEditSchema,
+  defaultUserProfileEditData,
+  validateProfileStep,
+  mapEditDataToUpdateRequest,
+  mapUserDataToEditForm,
+} from "../../types/user.types";
+
+/**
+ * ViewModel for profile editing
+ * Sprint #13 Tasks 10.1 + 10.2: User Profile Editing + Bio & Tags
+ */
+export interface EditProfileViewModel {
+  // Form state
+  form: UseFormReturn<UserProfileEditData>;
+
+  // Wizard state
+  wizardSteps: WizardStep<UserProfileEditData>[];
+  forceUpdate: () => void;
+
+  // Data loading state
+  isLoadingUserData: boolean;
+  loadUserError: string | null;
+
+  // Submit state
+  isSubmitting: boolean;
+  submitError: string | null;
+
+  // Actions
+  handleWizardSubmit: (data: UserProfileEditData) => Promise<void>;
+  handleCancel: () => void;
+}
+
+/**
+ * ViewModel para edición de perfil de usuario siguiendo patrón MVVM
+ *
+ * RESPONSABILIDADES:
+ * - Cargar datos del usuario autenticado al montar
+ * - Pre-poblar formulario con valores actuales
+ * - Gestionar estado del wizard multi-step con RHF integration
+ * - Validar datos por step usando schemas de contracts
+ * - Orquestar servicio de actualización de perfil
+ * - Actualizar AuthStore tras éxito
+ * - Manejar UI state (loading, errors)
+ * - Transformar datos entre UI format y API format
+ *
+ * FEATURES IMPLEMENTADAS:
+ * • React Hook Form con validación Zod
+ * • Wizard configuration con steps y validaciones
+ * • Carga inicial de datos del usuario
+ * • Manejo de errores granular
+ * • Sincronización perfecta wizard <-> RHF
+ * • Actualización del store tras éxito
+ */
+export function useEditProfileViewModel(): EditProfileViewModel {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+  const { user } = useAuth();
+  const updateUserInStore = useAuthStore((state) => state.updateUserProfile);
+
+  // React Hook Form con Zod validation
+  const form = useZodForm<UserProfileEditData>({
+    schema: UserProfileEditSchema,
+    defaultValues: defaultUserProfileEditData,
+    mode: "onChange",
+  });
+
+  // UI State
+  const [isLoadingUserData, setIsLoadingUserData] = useState(true);
+  const [loadUserError, setLoadUserError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+
+  // Force re-render when form state changes to make validation reactive
+  const [, forceUpdateReducer] = useReducer((x) => x + 1, 0);
+  const forceUpdate = useCallback(() => forceUpdateReducer(), []);
+
+  // Subscribe to form state changes for wizard reactivity
+  useEffect(() => {
+    const subscription = form.watch(() => {
+      forceUpdateReducer();
+    });
+    return () => subscription.unsubscribe();
+  }, [form]);
+
+  /**
+   * Load user data on mount and pre-populate form
+   */
+  useEffect(() => {
+    const loadUserData = async () => {
+      try {
+        setIsLoadingUserData(true);
+        setLoadUserError(null);
+
+        if (!user) {
+          throw new Error(t("profile.edit.errors.noUser"));
+        }
+
+        // Map user data to form format and pre-populate
+        const formData = mapUserDataToEditForm(user);
+        form.reset(formData);
+      } catch (error) {
+        const errorMessage =
+          error instanceof Error
+            ? error.message
+            : t("profile.edit.errors.loadUser");
+        setLoadUserError(errorMessage);
+        console.error("❌ Error loading user data:", error);
+      } finally {
+        setIsLoadingUserData(false);
+      }
+    };
+
+    loadUserData();
+  }, [user, form, t]);
+
+  /**
+   * Wizard steps configuration
+   */
+  const wizardSteps: WizardStep<UserProfileEditData>[] = [
+    {
+      title: t("profile.edit.steps.basicInfo.title"),
+      description: t("profile.edit.steps.basicInfo.description"),
+      component: BasicInfoStep,
+      isValid: () => {
+        // Validar usando schema Zod
+        const formData = form.getValues();
+        return validateProfileStep("basicInfo", formData);
+      },
+    },
+    {
+      title: t("profile.edit.steps.bioAndTags.title"),
+      description: t("profile.edit.steps.bioAndTags.description"),
+      component: BioAndTagsStep,
+      isValid: () => {
+        const formData = form.getValues();
+        return validateProfileStep("bioAndTags", formData);
+      },
+    },
+    {
+      title: t("profile.edit.steps.confirmation.title"),
+      description: t("profile.edit.steps.confirmation.description"),
+      component: ProfileConfirmationStep,
+      isValid: () => Object.keys(form.formState.errors).length === 0,
+    },
+  ];
+
+  /**
+   * Handle wizard submission
+   * Calls API, updates store, shows feedback, navigates
+   */
+  const handleWizardSubmit = useCallback(
+    async (wizardData: UserProfileEditData) => {
+      if (!user?.id) {
+        setSubmitError(t("profile.edit.errors.noUser"));
+        return;
+      }
+
+      try {
+        setIsSubmitting(true);
+        setSubmitError(null);
+
+        console.log("📤 Submitting profile update:", wizardData);
+
+        // Transform wizard data to API format
+        const apiData = mapEditDataToUpdateRequest(wizardData, user.id);
+        console.log("🔄 Mapped to API format:", apiData);
+
+        modal.showLoading("Actualizando perfil...");
+
+        // Call API
+        const response = await userService.updateMyProfile(apiData);
+        console.log("✅ Profile updated successfully:", response);
+
+        // Navigate back to profile after short delay
+        setTimeout(() => {
+          // Update AuthStore with new user data
+          updateUserInStore(response);
+          console.log("✅ AuthStore updated");
+
+        //   // Show success modal
+        //   modal.success({
+        //     title: t("profile.edit.success.title"),
+        //     description: t("profile.edit.success.description"),
+        //     dismissText: t("common.ok"),
+        //   });
+          // Show success toast
+          toast.success({
+            title: t("profile.edit.success.title"),
+            description: t("profile.edit.success.description"),
+          });
+          modal.hide();
+          navigate("/profile");
+        }, 1500);
+      } catch (error) {
+        console.error("❌ Error updating profile:", error);
+
+        const errorMessage =
+          error instanceof Error
+            ? error.message
+            : t("profile.edit.errors.update");
+
+        setSubmitError(errorMessage);
+
+        toast.error({
+          title: t("profile.edit.errors.title"),
+          description: errorMessage,
+        });
+
+        throw error;
+      } finally {
+        setIsSubmitting(false);
+      }
+    },
+    [navigate, t, updateUserInStore]
+  );
+
+  /**
+   * Handle cancel action
+   */
+  const handleCancel = useCallback(() => {
+    // Navigate back without saving
+    navigate("/profile");
+  }, [navigate]);
+
+  return {
+    // Form state
+    form,
+
+    // Wizard state
+    wizardSteps,
+    forceUpdate,
+
+    // Data loading state
+    isLoadingUserData,
+    loadUserError,
+
+    // Submit state
+    isSubmitting,
+    submitError,
+
+    // Actions
+    handleWizardSubmit,
+    handleCancel,
+  };
+}

--- a/apps/frontend/src/viewModels/users/index.ts
+++ b/apps/frontend/src/viewModels/users/index.ts
@@ -1,0 +1,7 @@
+/**
+ * Users ViewModels - Barrel export
+ * Sprint #12: User Discovery & Contact Management
+ */
+
+export * from './useUserDiscoveryViewModel';
+export * from './useMyContactsViewModel';

--- a/docs/SprintsPlanning.md
+++ b/docs/SprintsPlanning.md
@@ -712,13 +712,13 @@ Distribución por categoría:
 | Documentación | 20.1 Reporte Académico del Sprint #12 | 1 | 5 | |
 | Gestión | 20.2 Demo/UAT de Sprint #12 | 2 | 1.5 | 1.2 |
 | Gestión | 20.3 Sprint Planning de Sprint #13 | 3 | 1.3 | 2.5 |
-| Capacitación | 21.2 Tutorías (guía con tutor asignado) | 4 | 1 | |
-| Desarrollo | 10.1a User Editing - Domain + Persistence | 5 | 2 | |
-| Desarrollo | 10.1b User Editing - Application Backend | 6 | 3 | |
-| Desarrollo | 10.1c User Editing - Frontend UI | 7 | 3 | |
-| Desarrollo | 10.2a Bio & Tags - Domain + Persistence | 8 | 2 | |
-| Desarrollo | 10.2b Bio & Tags - Application Backend | 9 | 2 | |
-| Desarrollo | 10.2c Bio & Tags - Frontend UI | 10 | 2 | |
+| Capacitación | 21.2 Tutorías (guía con tutor asignado) | 4 | 1 | 1 |
+| Desarrollo | 10.1a User Editing - Domain + Persistence | 5 | 2 | 0.9 |
+| Desarrollo | 10.1b User Editing - Application Backend | 6 | 3 | 1.3 |
+| Desarrollo | 10.1c User Editing - Frontend UI | 7 | 3 | 2.5 |
+| Desarrollo | 10.2a Bio & Tags - Domain + Persistence | 8 | 2 | 0.5 |
+| Desarrollo | 10.2b Bio & Tags - Application Backend | 9 | 2 | 1.25 |
+| Desarrollo | 10.2c Bio & Tags - Frontend UI | 10 | 2 | 1.8 |
 | Desarrollo | 9.3e Chat Access Control - Accept Requests | 11 | 4 | |
 | Desarrollo | 9.3f Chat Access Control - Block Users | 12 | 3 | |
 | Desarrollo | 9.3g Chat Access Control - Request Tracking | 13 | 2 | |

--- a/packages/contracts/src/user-discovery.contract.ts
+++ b/packages/contracts/src/user-discovery.contract.ts
@@ -10,13 +10,15 @@ import type { IUserPublicProfile } from '@packages/domain';
  * Exposes only non-sensitive user data for public discovery
  * Uses satisfies to ensure compile-time validation against domain IUserPublicProfile
  * 
- * EXCLUDED (sensitive): email, phone, passwordHash, subscriptionLevel, notifications
- * INCLUDED (public): id, companyName, type, serviceAreas (providers), isVerified (providers)
+ * EXCLUDED (sensitive): email, phone, passwordHash, subscriptionLevel, notifications, address
+ * INCLUDED (public): id, companyName, bio, tags, type, serviceAreas (providers), isVerified (providers)
  */
 export const UserPublicProfileSchema = z.object({
   id: z.string(),
   profile: z.object({
-    companyName: z.string().optional()
+    companyName: z.string().optional(),
+    bio: z.string().optional(), // 🆕 Sprint #13 Task 10.2: Biografía pública
+    tags: z.array(z.string()).readonly().optional() // 🆕 Sprint #13 Task 10.2: Tags públicos (readonly para coincidir con domain)
   }),
   type: z.enum(['CLIENT', 'PROVIDER']),
   // Provider-specific fields (optional, only when type === 'PROVIDER')

--- a/packages/contracts/src/user.contract.ts
+++ b/packages/contracts/src/user.contract.ts
@@ -93,6 +93,8 @@ export const UserProfileSchema = z.object({
   )
     .max(USER_PROFILE_LIMITS.MAX_TAGS, `Maximum ${USER_PROFILE_LIMITS.MAX_TAGS} tags allowed`)
     .optional()
+    // NOTE: Duplicate check AFTER transform is intentional
+    // Example: ['Tag', 'tag'] → ['tag', 'tag'] → detects duplicate correctly (case-insensitive)
     .refine(
       (tags) => {
         if (!tags || tags.length === 0) return true;
@@ -136,7 +138,7 @@ export const GetUserRequestSchema = z.object({
 export const GetUserResponseSchema = CreateUserResponseSchema;
 
 /**
- * Schema para actualizar usuario
+ * Schema para actualizar usuario (admin use case - requiere id)
  */
 export const UpdateUserRequestSchema = z.object({
   id: z.string(),
@@ -145,6 +147,16 @@ export const UpdateUserRequestSchema = z.object({
 });
 
 export const UpdateUserResponseSchema = CreateUserResponseSchema;
+
+/**
+ * Schema para actualizar perfil propio (Sprint #13 Task 10.1+10.2)
+ * Para endpoint PATCH /users/me/profile - sin id porque viene del JWT
+ */
+export const UpdateMyProfileRequestSchema = z.object({
+  profile: UserProfileSchema.partial().optional()
+});
+
+export const UpdateMyProfileResponseSchema = CreateUserResponseSchema;
 
 /**
  * Schema para listar usuarios
@@ -171,6 +183,9 @@ export type GetUserResponse = z.infer<typeof GetUserResponseSchema>;
 
 export type UpdateUserRequest = z.infer<typeof UpdateUserRequestSchema>;
 export type UpdateUserResponse = z.infer<typeof UpdateUserResponseSchema>;
+
+export type UpdateMyProfileRequest = z.infer<typeof UpdateMyProfileRequestSchema>;
+export type UpdateMyProfileResponse = z.infer<typeof UpdateMyProfileResponseSchema>;
 
 export type ListUsersRequest = z.infer<typeof ListUsersRequestSchema>;
 export type ListUsersResponse = z.infer<typeof ListUsersResponseSchema>;

--- a/packages/contracts/src/user.contract.ts
+++ b/packages/contracts/src/user.contract.ts
@@ -2,6 +2,24 @@ import { z } from 'zod';
 import { SortOrderSchema, PaginationSchema, BasePaginatedResponseSchema } from './common.types';
 
 // =============================================================================
+// Validation Constants (Sprint #13 Task 10.2)
+// =============================================================================
+
+/**
+ * Límites de validación para todos los campos de UserProfile
+ * SSOT: Centralizados en capa de contracts para reutilización en frontend/backend
+ * Sprint #13 Task 10.1 + 10.2
+ */
+export const USER_PROFILE_LIMITS = {
+  MAX_COMPANY_NAME_LENGTH: 100,
+  MAX_PHONE_LENGTH: 20,
+  MAX_ADDRESS_LENGTH: 200,
+  MAX_BIO_LENGTH: 500,
+  MAX_TAGS: 5,
+  MAX_TAG_LENGTH: 100
+} as const;
+
+// =============================================================================
 // User Types & Enums
 // =============================================================================
 
@@ -21,6 +39,8 @@ export interface UserProfile {
   phone?: string;
   companyName?: string;
   address?: string;
+  bio?: string; // 🆕 Sprint #13 Task 10.2: Biografía
+  tags?: string[]; // 🆕 Sprint #13 Task 10.2: Tags/etiquetas
 }
 
 /**
@@ -44,11 +64,43 @@ export const UserTypeSchema = z.nativeEnum(UserType);
 
 /**
  * Schema basado en la interfaz UserProfile
+ * 🆕 Sprint #13 Task 10.1 + 10.2: Validaciones completas para todos los campos
+ * SSOT: Única fuente de verdad para validación de perfil de usuario
  */
 export const UserProfileSchema = z.object({
-  phone: z.string().optional(),
-  companyName: z.string().optional(),
-  address: z.string().optional()
+  phone: z.string()
+    .max(USER_PROFILE_LIMITS.MAX_PHONE_LENGTH, `Phone must be max ${USER_PROFILE_LIMITS.MAX_PHONE_LENGTH} characters`)
+    .trim()
+    .optional(),
+  companyName: z.string()
+    .max(USER_PROFILE_LIMITS.MAX_COMPANY_NAME_LENGTH, `Company name must be max ${USER_PROFILE_LIMITS.MAX_COMPANY_NAME_LENGTH} characters`)
+    .trim()
+    .optional(),
+  address: z.string()
+    .max(USER_PROFILE_LIMITS.MAX_ADDRESS_LENGTH, `Address must be max ${USER_PROFILE_LIMITS.MAX_ADDRESS_LENGTH} characters`)
+    .trim()
+    .optional(),
+  bio: z.string()
+    .max(USER_PROFILE_LIMITS.MAX_BIO_LENGTH, `Bio must be max ${USER_PROFILE_LIMITS.MAX_BIO_LENGTH} characters`)
+    .trim()
+    .optional(),
+  tags: z.array(
+    z.string()
+      .max(USER_PROFILE_LIMITS.MAX_TAG_LENGTH, `Each tag must be max ${USER_PROFILE_LIMITS.MAX_TAG_LENGTH} characters`)
+      .trim()
+      .min(1, 'Tags cannot be empty')
+      .transform(val => val.toLowerCase()) // Normalize to lowercase
+  )
+    .max(USER_PROFILE_LIMITS.MAX_TAGS, `Maximum ${USER_PROFILE_LIMITS.MAX_TAGS} tags allowed`)
+    .optional()
+    .refine(
+      (tags) => {
+        if (!tags || tags.length === 0) return true;
+        const uniqueTags = new Set(tags);
+        return uniqueTags.size === tags.length;
+      },
+      { message: 'Duplicate tags are not allowed' }
+    )
 }) satisfies z.ZodType<UserProfile>;
 
 /**

--- a/packages/domain/src/entities/user/user.entity.ts
+++ b/packages/domain/src/entities/user/user.entity.ts
@@ -251,6 +251,7 @@ export abstract class User {
       }
       
       // Validar que no haya tags duplicados (case-insensitive)
+      // NOTE: Zod contract layer ya valida esto post-transform, pero mantenemos defensa en profundidad
       const uniqueTags = new Set(profile.tags.map(t => t.toLowerCase().trim()));
       if (uniqueTags.size !== profile.tags.length) {
         return err(DomainError.validation('Duplicate tags are not allowed'));

--- a/packages/domain/src/entities/user/user.entity.ts
+++ b/packages/domain/src/entities/user/user.entity.ts
@@ -224,6 +224,39 @@ export abstract class User {
       }
     }
 
+    // 🆕 Sprint #13 Task 10.2: Validar bio si está presente
+    if (profile.bio !== undefined) {
+      if (profile.bio.trim().length === 0) {
+        return err(DomainError.validation('Bio cannot be empty when provided'));
+      }
+      if (profile.bio.length > 500) {
+        return err(DomainError.validation('Bio is too long (max 500 characters)'));
+      }
+    }
+
+    // 🆕 Sprint #13 Task 10.2: Validar tags si está presente
+    if (profile.tags !== undefined) {
+      if (profile.tags.length > 5) {
+        return err(DomainError.validation('Too many tags (max 5 tags)'));
+      }
+      
+      // Validar cada tag individualmente
+      for (const tag of profile.tags) {
+        if (typeof tag !== 'string' || tag.trim().length === 0) {
+          return err(DomainError.validation('Tags cannot be empty'));
+        }
+        if (tag.length > 100) {
+          return err(DomainError.validation('Tag is too long (max 100 characters)'));
+        }
+      }
+      
+      // Validar que no haya tags duplicados (case-insensitive)
+      const uniqueTags = new Set(profile.tags.map(t => t.toLowerCase().trim()));
+      if (uniqueTags.size !== profile.tags.length) {
+        return err(DomainError.validation('Duplicate tags are not allowed'));
+      }
+    }
+
     return ok(undefined);
   }
 
@@ -381,10 +414,16 @@ export abstract class User {
     createdAt: string;
     updatedAt: string;
   } {
+    // Convertir readonly string[] a string[] para compatibilidad con contratos
+    const profileCopy = { ...this.props.profile };
+    if (profileCopy.tags) {
+      (profileCopy as any).tags = [...profileCopy.tags]; // Cast de readonly a mutable
+    }
+    
     return {
       id: this.props.id.getValue(),
       email: this.props.email.getValue(),
-      profile: { ...this.props.profile },
+      profile: profileCopy,
       type: this.props.type,
       isActive: this.props.isActive,
       createdAt: this.props.createdAt.toISOString(),

--- a/packages/domain/src/models/index.ts
+++ b/packages/domain/src/models/index.ts
@@ -81,6 +81,8 @@ export interface IUserProfile {
   readonly phone?: string;
   readonly companyName?: string;
   readonly address?: string;
+  readonly bio?: string; // 🆕 Sprint #13 Task 10.2: Biografía (max 500 chars)
+  readonly tags?: readonly string[]; // 🆕 Sprint #13 Task 10.2: Tags/etiquetas (max 5, cada uno max 100 chars)
 }
 
 export interface IMachineSpecs {

--- a/packages/domain/src/models/interfaces.ts
+++ b/packages/domain/src/models/interfaces.ts
@@ -41,6 +41,8 @@ export interface IUser extends IBaseEntity {
     readonly phone?: string;
     readonly companyName?: string;
     readonly address?: string;
+    readonly bio?: string; // 🆕 Sprint #13 Task 10.2: Biografía (max 500 chars)
+    readonly tags?: readonly string[]; // 🆕 Sprint #13 Task 10.2: Tags/etiquetas (max 5, cada uno max 100 chars)
   };
   readonly type: 'CLIENT' | 'PROVIDER';
   readonly isActive: boolean;

--- a/packages/domain/src/models/interfaces.ts
+++ b/packages/domain/src/models/interfaces.ts
@@ -78,6 +78,8 @@ export interface IUserPublicProfile {
   readonly id: string;
   readonly profile: {
     readonly companyName?: string;
+    readonly bio?: string; // 🆕 Sprint #13 Task 10.2: Biografía pública (max 500 chars)
+    readonly tags?: readonly string[]; // 🆕 Sprint #13 Task 10.2: Tags públicos (max 5, cada uno max 100 chars)
   };
   readonly type: 'CLIENT' | 'PROVIDER';
   // Provider-specific fields (opcionales, solo para type === 'PROVIDER')
@@ -88,6 +90,8 @@ export interface IUserPublicProfile {
   // readonly machineCount?: number; // Cantidad de máquinas (para mostrar experiencia del cliente)
   // readonly rating?: number; // Rating promedio (para proveedores verificados)
   // readonly location?: string; // Ciudad/región (para búsquedas geográficas futuras)
+  // readonly responseTime?: string; // Tiempo promedio de respuesta (para mensajería - Sprint #12 Module 3)
+  // readonly completedJobs?: number; // Trabajos completados (para proveedores verificados)
 }
 
 /**

--- a/packages/persistence/src/models/user.model.ts
+++ b/packages/persistence/src/models/user.model.ts
@@ -172,10 +172,11 @@ const userSchema = new Schema<IUserDocument>({
     },
     tags: {
       type: [String],
-      default: undefined, // undefined permite distinguir "no set" vs "array vacío"
+      default: [], // Array vacío por default (idiomático Mongoose, consistente con contacts)
       validate: {
         validator: function(tags: string[] | undefined) {
-          if (!tags) return true; // undefined/null es válido
+          // Permitir undefined/null (edge case) y arrays válidos
+          if (!tags) return true;
           if (!Array.isArray(tags)) return false;
           if (tags.length > USER_PROFILE_LIMITS.MAX_TAGS) return false;
           


### PR DESCRIPTION
This pull request implements user profile editing functionality, allowing authenticated users to update their own profile, including new public fields like bio and tags. It introduces a new use case, controller, and route for PATCH `/users/me/profile`, with comprehensive validation and error handling. Additionally, it updates the user public profile mapping to expose the new fields and includes minor frontend and UX tweaks.

**User Profile Editing (Backend):**
- Added `UpdateUserProfileUseCase` to handle profile updates, supporting editable fields: phone, companyName, address, bio, and tags, with multi-layer validation and business rules.
- Introduced `UserController` with an `updateProfile` method, handling PATCH `/users/me/profile` requests, error mapping, and logging.
- Registered the new PATCH `/me/profile` route in `users.routes.ts` with OpenAPI docs, validation middleware, and controller integration.

**User Public Profile Mapping:**
- Updated `DiscoverUsersUseCase` and `ListContactsUseCase` to include `bio` and `tags` in the public profile, and exclude `address` from public exposure. [[1]](diffhunk://#diff-2310d9b98dd93cad40af6de0d86176594ae7dc1be3a8c46f63705f20287881e0L116-R127) [[2]](diffhunk://#diff-8509b7667c0c0d0cbb683274c73909a15bb03d4aee4ae6a7fe865606b8f80c41L78-R80)
- Adjusted type casting and return values for public profile mapping in both use cases. [[1]](diffhunk://#diff-2310d9b98dd93cad40af6de0d86176594ae7dc1be3a8c46f63705f20287881e0L136-R138) [[2]](diffhunk://#diff-8509b7667c0c0d0cbb683274c73909a15bb03d4aee4ae6a7fe865606b8f80c41L89-R91)
- Added TODO for future inclusion of rating and statistics in provider public profiles.

**Other Backend Adjustments:**
- Simplified return type casting in `LoginUserUseCase` for compatibility with the updated public profile structure.

**Frontend and UX Tweaks:**
- Reduced `TimerButton` duration from 5 to 3 seconds in `WizardControls` for a faster user experience.
- Removed an unnecessary `console.log` and commented out modal close logic in `GlobalModal` for cleaner UX and debugging. [[1]](diffhunk://#diff-e1f95fee050c2fa49f6a9375f54b65256b9e6eb3289b114d6bc07399ffdc9faeL75-R75) [[2]](diffhunk://#diff-e1f95fee050c2fa49f6a9375f54b65256b9e6eb3289b114d6bc07399ffdc9faeL117)