### PR TITLE
Feature/rework for machine type

### DIFF
--- a/apps/backend/src/application/dashboard/get-recent-machine-events.use-case.ts
+++ b/apps/backend/src/application/dashboard/get-recent-machine-events.use-case.ts
@@ -85,7 +85,7 @@ export class GetRecentMachineEventsUseCase {
           id: item.machine.id,
           name: item.machine.name,
           serialNumber: item.machine.serialNumber,
-          machineType: item.machine.machineType || undefined
+          machineTypeName: item.machine.machineTypeName || undefined
         }
       }));
 

--- a/apps/backend/src/application/dashboard/get-recent-quickchecks.use-case.ts
+++ b/apps/backend/src/application/dashboard/get-recent-quickchecks.use-case.ts
@@ -92,7 +92,7 @@ export class GetRecentQuickChecksUseCase {
             brand: item.machine.brand,
             model: item.machine.model,
             serialNumber: item.machine.serialNumber,
-            machineType: item.machine.machineType || undefined
+            machineTypeName: item.machine.machineTypeName || undefined
           }
         };
       });

--- a/apps/backend/src/application/inventory/create-machine-type.use-case.ts
+++ b/apps/backend/src/application/inventory/create-machine-type.use-case.ts
@@ -4,6 +4,11 @@ import { logger } from '../../config/logger.config';
 import { CreateMachineTypeRequest } from '@packages/contracts';
 
 /**
+ * LEGACY Use Case - Machine types are now free-text fields
+ * 
+ * Este use case se mantiene para backward compatibility y para población inicial
+ * de sugerencias de tipos, pero las máquinas ya no dependen de estos registros.
+ * 
  * Use Case para crear un nuevo tipo de máquina
  * Utiliza lógica inteligente: si el tipo ya existe, agrega el idioma; si no, lo crea
  */

--- a/apps/backend/src/application/inventory/create-machine.use-case.ts
+++ b/apps/backend/src/application/inventory/create-machine.use-case.ts
@@ -1,5 +1,5 @@
 import { Machine, UsageSchedule, NOTIFICATION_TYPES, NOTIFICATION_SOURCE_TYPES } from '@packages/domain';
-import { MachineRepository, MachineTypeRepository } from '@packages/persistence';
+import { MachineRepository, /* LEGACY: MachineTypeRepository */ } from '@packages/persistence';
 import { logger } from '../../config/logger.config';
 import { CreateMachineRequest } from '@packages/contracts';
 import { AddNotificationUseCase } from '../notifications/add-notification.use-case';
@@ -11,12 +11,14 @@ import { NOTIFICATION_MESSAGE_KEYS } from '../../constants/notification-messages
  */
 export class CreateMachineUseCase {
   private machineRepository: MachineRepository;
-  private machineTypeRepository: MachineTypeRepository;
+  // LEGACY: MachineType validation no longer needed (free-text machineTypeName)
+  // private machineTypeRepository: MachineTypeRepository;
   private addNotificationUseCase: AddNotificationUseCase;
 
   constructor() {
     this.machineRepository = new MachineRepository();
-    this.machineTypeRepository = new MachineTypeRepository();
+    // LEGACY: No longer validate machineTypeId existence
+    // this.machineTypeRepository = new MachineTypeRepository();
     this.addNotificationUseCase = new AddNotificationUseCase();
   }
 
@@ -38,11 +40,11 @@ export class CreateMachineUseCase {
         throw new Error(`Serial number ${request.serialNumber} already exists`);
       }
 
-      // Validar que el machine type exista
-      const machineType = await this.machineTypeRepository.findById(request.machineTypeId);
-      if (!machineType) {
-        throw new Error(`Machine type with ID ${request.machineTypeId} not found`);
-      }
+      // LEGACY: Machine type validation removed (now free-text machineTypeName)
+      // const machineType = await this.machineTypeRepository.findById(request.machineTypeId);
+      // if (!machineType) {
+      //   throw new Error(`Machine type with ID ${request.machineTypeId} not found`);
+      // }
 
       // Crear UsageSchedule VO si viene en request
       let usageSchedule: UsageSchedule | undefined;
@@ -62,7 +64,7 @@ export class CreateMachineUseCase {
         serialNumber: request.serialNumber,
         brand: request.brand,
         modelName: request.modelName,
-        machineTypeId: request.machineTypeId,
+        machineTypeName: request.machineTypeName,
         ownerId: request.ownerId,
         createdById: request.createdById,
         nickname: request.nickname,
@@ -99,7 +101,8 @@ export class CreateMachineUseCase {
       try {
         const ownerId = machine.ownerId.getValue();
         const machineName = machine.nickname || machine.serialNumber.getValue();
-        const machineTypeName = machineType.name; // Ya disponible de validación anterior (línea 38)
+        // NEW: Use machineTypeName directly from machine entity (free-text field)
+        const machineTypeName = machine.machineTypeName;
 
         await this.addNotificationUseCase.execute(ownerId, {
           notificationType: NOTIFICATION_TYPES[0], // 'success'

--- a/apps/backend/src/application/inventory/delete-machine-type.use-case.ts
+++ b/apps/backend/src/application/inventory/delete-machine-type.use-case.ts
@@ -2,6 +2,11 @@ import { MachineTypeRepository } from '@packages/persistence';
 import { logger } from '../../config/logger.config';
 
 /**
+ * LEGACY Use Case - Machine types are now free-text fields
+ * 
+ * Este use case se mantiene para backward compatibility pero ya no es crítico
+ * dado que las máquinas usan machineTypeName (free-text) en lugar de referencias.
+ * 
  * Use Case para eliminar un tipo de máquina
  * 
  * TODO: Implementar control de acceso - solo usuarios ADMIN deberían poder eliminar tipos
@@ -10,18 +15,9 @@ import { logger } from '../../config/logger.config';
  *   throw new Error('Only administrators can delete machine types');
  * }
  * 
- * TODO: Implementar verificación de uso antes de eliminar (prevenir pérdida de datos)
- * Se recomienda usar soft delete o verificar que no haya máquinas usando este tipo.
- * Ejemplo:
- * const machinesCount = await this.machineTypeRepository.countMachinesUsingType(id);
- * if (machinesCount > 0) {
- *   throw new Error(`Cannot delete machine type: ${machinesCount} machines are using it. Consider marking as inactive instead.`);
- * }
- * 
- * Alternativamente, se puede implementar soft delete agregando un campo "isActive" al modelo:
- * - En lugar de eliminar físicamente, marcar como isActive: false
- * - Filtrar tipos inactivos en las consultas de lista
- * - Permitir reactivar tipos si es necesario
+ * NOTA: La verificación de uso ya no aplica con el nuevo modelo free-text.
+ * Las máquinas ya no dependen de registros en MachineType collection.
+ * LEGACY: Verificación de uso comentada (líneas 54-59)
  */
 export class DeleteMachineTypeUseCase {
   private machineTypeRepository: MachineTypeRepository;
@@ -47,7 +43,8 @@ export class DeleteMachineTypeUseCase {
         throw new Error('Machine type not found');
       }
 
-      // TODO: Descomentar cuando Machine esté implementado
+      // LEGACY: Machine usage validation no longer needed (free-text machineTypeName)
+      // Machines no longer depend on MachineType records, safe to delete
       // const machinesCount = await this.machineTypeRepository.countMachinesUsingType(id);
       // if (machinesCount > 0) {
       //   logger.warn({ id, machinesCount }, 'Cannot delete machine type in use');

--- a/apps/backend/src/application/inventory/list-machine-types.use-case.ts
+++ b/apps/backend/src/application/inventory/list-machine-types.use-case.ts
@@ -3,6 +3,14 @@ import { MachineType } from '@packages/domain';
 import { logger } from '../../config/logger.config';
 
 /**
+ * LEGACY Use Case - Machine types are now free-text fields
+ * 
+ * Este use case se mantiene para:
+ * 1. Backward compatibility con APIs existentes
+ * 2. Proporcionar sugerencias de tipos comunes en UI (dropdown/combobox)
+ * 
+ * Las máquinas ya no dependen de estos registros (usan machineTypeName libre).
+ * 
  * Use Case para listar tipos de máquina
  * Opcionalmente puede filtrar por idioma
  */

--- a/apps/backend/src/application/inventory/list-machines.use-case.ts
+++ b/apps/backend/src/application/inventory/list-machines.use-case.ts
@@ -60,7 +60,9 @@ export class ListMachinesUseCase {
         filter: {
           ownerId: filter.ownerId,
           assignedProviderId: filter.assignedProviderId,
-          machineTypeId: filter.machineTypeId,
+          machineTypeName: filter.machineTypeName, // NEW: Free-text filter
+          // LEGACY: machineTypeId filter removed
+          // machineTypeId: filter.machineTypeId,
           status: filter.status,
           brand: filter.brand,
           searchTerm: filter.search

--- a/apps/backend/src/application/inventory/update-machine-type.use-case.ts
+++ b/apps/backend/src/application/inventory/update-machine-type.use-case.ts
@@ -4,6 +4,11 @@ import { logger } from '../../config/logger.config';
 import { UpdateMachineTypeRequest } from '@packages/contracts';
 
 /**
+ * LEGACY Use Case - Machine types are now free-text fields
+ * 
+ * Este use case se mantiene para backward compatibility pero ya no es crítico
+ * dado que las máquinas usan machineTypeName (free-text) en lugar de referencias.
+ * 
  * Use Case para actualizar el nombre de un tipo de máquina
  * 
  * TODO: Implementar control de acceso - solo usuarios ADMIN deberían poder actualizar tipos

--- a/apps/backend/src/application/inventory/update-machine.use-case.ts
+++ b/apps/backend/src/application/inventory/update-machine.use-case.ts
@@ -64,14 +64,18 @@ export class UpdateMachineUseCase {
       if (request.brand !== undefined) updates.brand = request.brand;
       if (request.modelName !== undefined) updates.modelName = request.modelName;
       if (request.nickname !== undefined) updates.nickname = request.nickname;
-      if (request.machineTypeId !== undefined) {
-        // TODO: Strategic enhancement - Validate machineTypeId exists before allowing update
-        // const machineTypeRepo = new MachineTypeRepository();
-        // const typeExists = await machineTypeRepo.findById(request.machineTypeId);
-        // if (!typeExists) throw new Error('Invalid machine type ID - type does not exist');
-        // Purpose: Prevent referential integrity issues (orphaned machineTypeId references)
-        updates.machineTypeId = request.machineTypeId;
+      if (request.machineTypeName !== undefined) {
+        // NEW: Free-text machineTypeName - no validation needed
+        // Users can enter any machine type name (2-50 characters)
+        updates.machineTypeName = request.machineTypeName;
       }
+      // LEGACY: machineTypeId validation commented out (no longer used)
+      // if (request.machineTypeId !== undefined) {
+      //   const machineTypeRepo = new MachineTypeRepository();
+      //   const typeExists = await machineTypeRepo.findById(request.machineTypeId);
+      //   if (!typeExists) throw new Error('Invalid machine type ID - type does not exist');
+      //   updates.machineTypeId = request.machineTypeId;
+      // }
 
       // Assignment
       if (request.assignedTo !== undefined) updates.assignedTo = request.assignedTo;

--- a/apps/backend/src/controllers/machine-type.controller.ts
+++ b/apps/backend/src/controllers/machine-type.controller.ts
@@ -9,16 +9,18 @@ import {
 import { MachineTypeResponse } from '@packages/contracts';
 import { MachineType } from '@packages/domain';
 
-/** * LEGACY Controller - Machine types are now free-text fields
- * 
+/**
+ * LEGACY Controller - Machine types are now free-text fields
+ *
  * Este controller se mantiene para:
  * 1. Backward compatibility con APIs existentes
  * 2. Administración de sugerencias de tipos comunes
  * 3. Seeding inicial de tipos predefinidos
- * 
+ *
  * Las máquinas ya no dependen de estos registros.
- *  * MachineTypeController handles machine type-related HTTP requests
- * 
+ *
+ * MachineTypeController handles machine type-related HTTP requests
+ *
  * Responsibilities:
  * - Call appropriate Use Cases (validation ya se hace en middleware)
  * - Transform domain responses to HTTP responses

--- a/apps/backend/src/controllers/machine-type.controller.ts
+++ b/apps/backend/src/controllers/machine-type.controller.ts
@@ -9,8 +9,15 @@ import {
 import { MachineTypeResponse } from '@packages/contracts';
 import { MachineType } from '@packages/domain';
 
-/**
- * MachineTypeController handles machine type-related HTTP requests
+/** * LEGACY Controller - Machine types are now free-text fields
+ * 
+ * Este controller se mantiene para:
+ * 1. Backward compatibility con APIs existentes
+ * 2. Administración de sugerencias de tipos comunes
+ * 3. Seeding inicial de tipos predefinidos
+ * 
+ * Las máquinas ya no dependen de estos registros.
+ *  * MachineTypeController handles machine type-related HTTP requests
  * 
  * Responsibilities:
  * - Call appropriate Use Cases (validation ya se hace en middleware)

--- a/apps/backend/src/controllers/machine.controller.ts
+++ b/apps/backend/src/controllers/machine.controller.ts
@@ -48,7 +48,7 @@ export class MachineController {
       brand: publicInterface.brand,
       modelName: publicInterface.modelName,
       nickname: publicInterface.nickname ?? null,
-      machineTypeId: publicInterface.machineTypeId,
+      machineTypeName: publicInterface.machineTypeName, // NEW: Free-text field
       ownerId: publicInterface.ownerId,
       createdById: publicInterface.createdById,
       assignedProviderId: publicInterface.assignedProviderId,

--- a/apps/backend/src/main.ts
+++ b/apps/backend/src/main.ts
@@ -13,7 +13,7 @@ import routes from './routes';
 import { connectDatabase } from './config/database.config';
 import { seedMachineTypesIfEmpty } from './scripts/seed-machine-types';
 import { syncMachineEventTypes } from './scripts/seed-machine-event-types';
-import { migrateMachineTypeToText } from './scripts/migrate-machine-type-to-text';
+import { migrateMachineTypeToText, checkMigrationStatus } from './scripts/migrate-machine-type-to-text';
 import { MaintenanceCronService } from './services/cron/maintenance-cron.service';
 
 const app = express();
@@ -134,22 +134,28 @@ app.get('/api', (req, res) => {
     // SAFE: Solo actualiza máquinas que NO tienen machineTypeName
     try {
       console.log('🔄 Checking if machine type migration is needed...');
-      const migrationStats = await migrateMachineTypeToText(false); // false = production mode
       
-      if (migrationStats.migrated > 0) {
-        console.log(`✅ Machine type migration completed: ${migrationStats.migrated} machines updated`);
-        if (migrationStats.fallbackUsed > 0) {
-          console.warn(`⚠️  ${migrationStats.fallbackUsed} machines used fallback (check logs for details)`);
+      const migrationStatus = await checkMigrationStatus();
+      
+      if (migrationStatus.needsMigration === 0) {
+        console.log(`✅ Machine type migration not needed (${migrationStatus.alreadyMigrated} machines already up-to-date)`);
+      } else {
+        console.log(`🔄 ${migrationStatus.needsMigration} machine(s) need migration, running...`);
+        const migrationStats = await migrateMachineTypeToText(false); // false = production mode
+        
+        if (migrationStats.migrated > 0) {
+          console.log(`✅ Machine type migration completed: ${migrationStats.migrated} machines updated`);
+          if (migrationStats.fallbackUsed > 0) {
+            console.warn(`⚠️  ${migrationStats.fallbackUsed} machines used fallback (check logs for details)`);
+          }
         }
-      } else if (migrationStats.skipped > 0) {
-        console.log(`✅ Machine type migration already completed (${migrationStats.skipped} machines up-to-date)`);
-      }
-      
-      if (migrationStats.errors > 0) {
-        console.error(`❌ ${migrationStats.errors} errors during migration (check logs)`);
+        
+        if (migrationStats.errors > 0) {
+          console.error(`❌ ${migrationStats.errors} errors during migration (check logs)`);
+        }
       }
     } catch (migrationError) {
-      console.error('❌ Machine type migration failed (non-critical - server will continue):', migrationError);
+      console.error('❌ Machine type migration check failed (non-critical - server will continue):', migrationError);
     }
     
     // 3. Inicializar y arrancar cronjobs

--- a/apps/backend/src/main.ts
+++ b/apps/backend/src/main.ts
@@ -13,6 +13,7 @@ import routes from './routes';
 import { connectDatabase } from './config/database.config';
 import { seedMachineTypesIfEmpty } from './scripts/seed-machine-types';
 import { syncMachineEventTypes } from './scripts/seed-machine-event-types';
+import { migrateMachineTypeToText } from './scripts/migrate-machine-type-to-text';
 import { MaintenanceCronService } from './services/cron/maintenance-cron.service';
 
 const app = express();
@@ -127,6 +128,29 @@ app.get('/api', (req, res) => {
     
     // 2b. Seed de MachineTypes (tipos de máquina)
     await seedMachineTypesIfEmpty();
+    
+    // 2c. Migración automática: machineTypeId (ObjectId) → machineTypeName (free-text)
+    // Sprint #XX: Ejecuta migración de datos legacy si es necesario
+    // SAFE: Solo actualiza máquinas que NO tienen machineTypeName
+    try {
+      console.log('🔄 Checking if machine type migration is needed...');
+      const migrationStats = await migrateMachineTypeToText(false); // false = production mode
+      
+      if (migrationStats.migrated > 0) {
+        console.log(`✅ Machine type migration completed: ${migrationStats.migrated} machines updated`);
+        if (migrationStats.fallbackUsed > 0) {
+          console.warn(`⚠️  ${migrationStats.fallbackUsed} machines used fallback (check logs for details)`);
+        }
+      } else if (migrationStats.skipped > 0) {
+        console.log(`✅ Machine type migration already completed (${migrationStats.skipped} machines up-to-date)`);
+      }
+      
+      if (migrationStats.errors > 0) {
+        console.error(`❌ ${migrationStats.errors} errors during migration (check logs)`);
+      }
+    } catch (migrationError) {
+      console.error('❌ Machine type migration failed (non-critical - server will continue):', migrationError);
+    }
     
     // 3. Inicializar y arrancar cronjobs
     // Sprint #11: Maintenance Alarms - Daily cronjob for automatic maintenance alerts

--- a/apps/backend/src/routes/machine-type.routes.ts
+++ b/apps/backend/src/routes/machine-type.routes.ts
@@ -13,6 +13,15 @@ const router = Router();
 const machineTypeController = new MachineTypeController();
 
 /**
+ * LEGACY ROUTES - Machine types are now free-text fields
+ * 
+ * Estas rutas se mantienen para:
+ * 1. Backward compatibility con clientes existentes
+ * 2. Administración de sugerencias de tipos comunes
+ * 3. Proporcionar listados para UI dropdowns/comboboxes
+ * 
+ * Las máquinas ya no dependen de estos registros (usan machineTypeName libre).
+ * 
  * RUTAS DE TIPOS DE MÁQUINA
  * Endpoints CRUD para gestión de tipos de máquina
  */

--- a/apps/backend/src/routes/machines.routes.ts
+++ b/apps/backend/src/routes/machines.routes.ts
@@ -44,9 +44,10 @@ const machineController = new MachineController();
  *           type: string
  *           enum: [ACTIVE, MAINTENANCE, OUT_OF_SERVICE, RETIRED]
  *       - in: query
- *         name: machineTypeId
+ *         name: machineTypeName
  *         schema:
  *           type: string
+ *         description: Filter by machine type name (free-text)
  *       - in: query
  *         name: search
  *         schema:
@@ -84,7 +85,7 @@ router.get('/',
  *               - serialNumber
  *               - brand
  *               - modelName
- *               - machineTypeId
+ *               - machineTypeName
  *             properties:
  *               serialNumber:
  *                 type: string
@@ -95,8 +96,10 @@ router.get('/',
  *               modelName:
  *                 type: string
  *                 example: "8FBE20"
- *               machineTypeId:
+ *               machineTypeName:
  *                 type: string
+ *                 example: "Autoelevador"
+ *                 description: Free-text machine type (2-50 characters)
  *               nickname:
  *                 type: string
  *               specs:

--- a/apps/backend/src/scripts/migrate-machine-type-to-text.ts
+++ b/apps/backend/src/scripts/migrate-machine-type-to-text.ts
@@ -226,10 +226,12 @@ export async function migrateMachineTypeToText(dryRun: boolean = false): Promise
     return stats;
 
   } catch (error: any) {
-    // No lanzar error para evitar que falle el startup del servidor si se llama desde main.ts
-    // Solo loguear y retornar stats con el error
-    logger.error({ error: error.message }, 'Critical error during migration (non-critical, returning stats)');
-    throw error;
+    // No relanzar: esta función es llamada desde main.ts al startup.
+    // Si falla, el servidor debe continuar igualmente (datos legacy no deben bloquear arranque).
+    logger.error({ error: error.message }, 'Critical error during migration (non-critical, server will continue)');
+    stats.errors++;
+    stats.errorDetails.push({ machineId: 'GLOBAL', error: error.message });
+    return stats;
   }
 }
 

--- a/apps/backend/src/scripts/migrate-machine-type-to-text.ts
+++ b/apps/backend/src/scripts/migrate-machine-type-to-text.ts
@@ -1,0 +1,317 @@
+import { MachineModel } from '@packages/persistence';
+import { MachineTypeModel } from '@packages/persistence';
+import { logger } from '../config/logger.config';
+
+/**
+ * Script de Migración: machineTypeId (ObjectId) → machineTypeName (free-text)
+ * 
+ * PROPÓSITO:
+ * Migrar máquinas existentes desde el modelo antiguo (referencia a MachineType por ID)
+ * al nuevo modelo (nombre de tipo como texto libre).
+ * 
+ * ESTRATEGIA:
+ * 1. Leer todas las máquinas de la DB
+ * 2. Para cada máquina con machineTypeId:
+ *    a. Buscar el registro en MachineType collection por ese ID
+ *    b. Obtener el campo 'name' del registro
+ *    c. Asignar ese nombre al nuevo campo machineTypeName
+ *    d. Si no existe el registro o no tiene nombre → asignar "EDITAR"
+ * 3. Actualizar documento en MongoDB
+ * 4. Log de progreso detallado
+ * 
+ * ROLLBACK:
+ * Este script NO elimina el campo machineTypeId antiguo (solo deja de usarse).
+ * Para rollback manual: volver a desplegar código antiguo y los datos siguen disponibles.
+ * 
+ * EJECUCIÓN:
+ * - Standalone: pnpm tsx apps/backend/src/scripts/migrate-machine-type-to-text.ts [--dry-run] [--check]
+ * - Desde código: import { migrateMachineTypeToText } from './scripts/migrate-machine-type-to-text'
+ * 
+ * SEGURIDAD:
+ * - Dry-run mode disponible (solo simula, no escribe)
+ * - Backup recomendado antes de ejecutar
+ * - Operaciones atómicas por documento
+ */
+
+interface MigrationStats {
+  totalMachines: number;
+  migrated: number;
+  skipped: number; // Ya tenían machineTypeName
+  fallbackUsed: number; // Se usó "EDITAR" como fallback
+  errors: number;
+  errorDetails: Array<{ machineId: string; error: string }>;
+}
+
+/**
+ * Verifica el estado de la migración sin ejecutarla.
+ * Útil para saber cuántas máquinas necesitan migración.
+ * 
+ * IMPORTANTE: Esta función NO maneja la conexión a MongoDB.
+ * Debe ser llamada después de que mongoose ya esté conectado.
+ * 
+ * @returns Promise con estadísticas de estado
+ */
+export async function checkMigrationStatus(): Promise<{
+  totalMachines: number;
+  alreadyMigrated: number;
+  needsMigration: number;
+  withoutTypeId: number;
+}> {
+  const totalMachines = await MachineModel.countDocuments({});
+  const alreadyMigrated = await MachineModel.countDocuments({ machineTypeName: { $exists: true } });
+  const withoutTypeId = await MachineModel.countDocuments({ 
+    machineTypeId: { $exists: false },
+    machineTypeName: { $exists: false }
+  });
+  const needsMigration = totalMachines - alreadyMigrated;
+
+  return {
+    totalMachines,
+    alreadyMigrated,
+    needsMigration,
+    withoutTypeId
+  };
+}
+
+/**
+ * Función principal de migración que puede ser llamada desde código.
+ * 
+ * IMPORTANTE: Esta función NO maneja la conexión a MongoDB.
+ * Debe ser llamada después de que mongoose ya esté conectado.
+ * 
+ * Flujo:
+ * 1. Lee todas las máquinas de la DB
+ * 2. Para cada máquina sin machineTypeName:
+ *    - Si tiene machineTypeId → busca nombre en MachineType collection
+ *    - Si no encuentra o no tiene ID → usa fallback "EDITAR"
+ * 3. Actualiza documento con nuevo campo
+ * 4. Retorna estadísticas de la migración
+ * 
+ * @param dryRun - Si es true, solo simula sin escribir a DB
+ * @returns Promise<MigrationStats> - Estadísticas de la migración
+ */
+export async function migrateMachineTypeToText(dryRun: boolean = false): Promise<MigrationStats> {
+  const stats: MigrationStats = {
+    totalMachines: 0,
+    migrated: 0,
+    skipped: 0,
+    fallbackUsed: 0,
+    errors: 0,
+    errorDetails: []
+  };
+
+  try {
+    logger.info({ dryRun }, 'Starting machine type migration');
+
+    // 1. Obtener todas las máquinas
+    const machines = await MachineModel.find({}).select('_id serialNumber machineTypeId machineTypeName');
+    stats.totalMachines = machines.length;
+
+    logger.info({ totalMachines: stats.totalMachines }, 'Found machines to process');
+
+    // 2. Procesar cada máquina
+    for (const machine of machines) {
+      try {
+        // Skip si ya tiene machineTypeName (migración ya ejecutada)
+        if (machine.machineTypeName) {
+          stats.skipped++;
+          logger.debug({ 
+            machineId: machine._id, 
+            machineTypeName: machine.machineTypeName 
+          }, 'Machine already has machineTypeName, skipping');
+          continue;
+        }
+
+        // Validar que tenga machineTypeId (campo antiguo)
+        // NOTA: machineTypeId es legacy, accedemos mediante any por backwards compatibility
+        const doc = machine as any;
+        if (!doc.machineTypeId) {
+          stats.fallbackUsed++;
+          const fallbackName = 'EDITAR';
+          
+          logger.warn({ 
+            machineId: machine._id,
+            serialNumber: machine.serialNumber 
+          }, 'Machine has no machineTypeId, using fallback');
+
+          if (!dryRun) {
+            await MachineModel.updateOne(
+              { _id: machine._id },
+              { 
+                $set: { 
+                  machineTypeName: fallbackName,
+                  updatedAt: new Date()
+                } 
+              }
+            );
+          }
+          
+          stats.migrated++;
+          continue;
+        }
+
+        // 3. Buscar el tipo de máquina en la collection MachineType
+        const machineType = await MachineTypeModel.findById(doc.machineTypeId);
+
+        let machineTypeName: string;
+
+        if (!machineType || !machineType.name) {
+          // No se encontró el registro o no tiene nombre → usar fallback
+          stats.fallbackUsed++;
+          machineTypeName = 'EDITAR';
+          
+          logger.warn({ 
+            machineId: machine._id,
+            machineTypeId: doc.machineTypeId,
+            serialNumber: machine.serialNumber
+          }, 'MachineType not found or has no name, using fallback');
+        } else {
+          // Usar el nombre del registro encontrado
+          machineTypeName = machineType.name;
+          
+          logger.debug({ 
+            machineId: machine._id,
+            machineTypeId: doc.machineTypeId,
+            machineTypeName,
+            serialNumber: machine.serialNumber
+          }, 'Found machineType name');
+        }
+
+        // 4. Actualizar la máquina con el nuevo campo
+        if (!dryRun) {
+          await MachineModel.updateOne(
+            { _id: machine._id },
+            { 
+              $set: { 
+                machineTypeName,
+                updatedAt: new Date()
+              }
+              // NOTA: NO eliminamos machineTypeId (mantener para rollback)
+              // Si quieres eliminarlo: $unset: { machineTypeId: '' }
+            }
+          );
+        }
+
+        stats.migrated++;
+        
+        // Log de progreso cada 10 máquinas
+        if (stats.migrated % 10 === 0) {
+          logger.info({ 
+            progress: `${stats.migrated}/${stats.totalMachines}`,
+            fallbackUsed: stats.fallbackUsed
+          }, 'Migration progress');
+        }
+
+      } catch (error: any) {
+        stats.errors++;
+        stats.errorDetails.push({
+          machineId: machine._id,
+          error: error.message
+        });
+        
+        logger.error({ 
+          machineId: machine._id,
+          error: error.message,
+          serialNumber: machine.serialNumber
+        }, 'Error migrating machine');
+      }
+    }
+
+    // 5. Log final de estadísticas
+    logger.info({ 
+      stats,
+      dryRun 
+    }, 'Migration completed');
+
+    return stats;
+
+  } catch (error: any) {
+    // No lanzar error para evitar que falle el startup del servidor si se llama desde main.ts
+    // Solo loguear y retornar stats con el error
+    logger.error({ error: error.message }, 'Critical error during migration (non-critical, returning stats)');
+    throw error;
+  }
+}
+
+// ============================================================================
+// SCRIPT STANDALONE - Solo se ejecuta si se corre directamente este archivo
+// ============================================================================
+// Para ejecutar manualmente: 
+//   pnpm tsx apps/backend/src/scripts/migrate-machine-type-to-text.ts
+//   pnpm tsx apps/backend/src/scripts/migrate-machine-type-to-text.ts --dry-run
+//   pnpm tsx apps/backend/src/scripts/migrate-machine-type-to-text.ts --check
+// Esto permite ejecutar la migración sin levantar el servidor completo
+
+if (require.main === module) {
+  import('mongoose').then(async (mongoose) => {
+    try {
+      // Leer argumentos de línea de comandos
+      const args = process.argv.slice(2);
+      const dryRun = args.includes('--dry-run');
+      const checkOnly = args.includes('--check');
+
+      const mongoUri = process.env.MONGO_URI || process.env.MONGODB_URI || 'mongodb://127.0.0.1:27017/fleetman';
+      await mongoose.default.connect(mongoUri);
+      
+      console.log('✅ Connected to MongoDB');
+      logger.info({ dryRun, checkOnly }, 'Machine Type Migration Script (Standalone Mode)');
+
+      if (checkOnly) {
+        // Solo verificar estado
+        const status = await checkMigrationStatus();
+        console.log('\n=== MIGRATION STATUS ===');
+        console.log(`Total Machines: ${status.totalMachines}`);
+        console.log(`Already Migrated: ${status.alreadyMigrated}`);
+        console.log(`Needs Migration: ${status.needsMigration}`);
+        console.log(`Without TypeId: ${status.withoutTypeId}`);
+        console.log('========================\n');
+      } else {
+        // Ejecutar migración
+        if (dryRun) {
+          console.log('\n⚠️  DRY-RUN MODE - No changes will be written to database\n');
+        } else {
+          console.log('\n🚀 PRODUCTION MODE - Changes will be written to database');
+          console.log('⚠️  Press Ctrl+C within 5 seconds to abort...\n');
+          await new Promise(resolve => setTimeout(resolve, 5000));
+        }
+
+        const stats = await migrateMachineTypeToText(dryRun);
+
+        // Mostrar resumen final
+        console.log('\n=== MIGRATION SUMMARY ===');
+        console.log(`Total Machines: ${stats.totalMachines}`);
+        console.log(`Migrated: ${stats.migrated}`);
+        console.log(`Skipped (already migrated): ${stats.skipped}`);
+        console.log(`Fallback used ("EDITAR"): ${stats.fallbackUsed}`);
+        console.log(`Errors: ${stats.errors}`);
+        
+        if (stats.errorDetails.length > 0) {
+          console.log('\nErrors:');
+          stats.errorDetails.forEach(err => {
+            console.log(`  - Machine ${err.machineId}: ${err.error}`);
+          });
+        }
+        
+        console.log('=========================\n');
+
+        if (!dryRun && stats.migrated > 0) {
+          console.log('✅ Migration completed successfully!');
+          console.log('Next steps:');
+          console.log('1. Verify the migration in MongoDB:');
+          console.log('   db.machines.find({ machineTypeName: { $exists: true } }).count()');
+          console.log('2. Check fallback cases:');
+          console.log('   db.machines.find({ machineTypeName: "EDITAR" })');
+          console.log('3. Deploy frontend changes to use machineTypeName\n');
+        }
+      }
+
+      await mongoose.default.disconnect();
+      console.log('✅ Disconnected from MongoDB');
+      process.exit(0);
+
+    } catch (error) {
+      console.error('❌ Error in standalone migration script:', error);
+      process.exit(1);
+    }
+  });
+}

--- a/apps/frontend/src/components/layout/MainLayout.tsx
+++ b/apps/frontend/src/components/layout/MainLayout.tsx
@@ -4,16 +4,19 @@ import { NavBar } from './NavBar';
 import { MobileBottomNav } from './MobileBottomNav';
 import { NavigationDrawer } from './NavigationDrawer';
 import { useNavigationSync } from '@hooks/useNavigationSync';
-import { useMachineTypes, useNotificationObserver } from '@hooks';
+// LEGACY: useMachineTypes no longer needed (free-text machineTypeName)
+// import { useMachineTypes, useNotificationObserver } from '@hooks';
+import { useNotificationObserver } from '@hooks';
 import { GlobalQuickActions } from '../dashboard';
 
 export const MainLayout: React.FC = () => {
   // Sync current route with navigation store
   useNavigationSync();
   
+  // LEGACY: Pre-fetch no longer needed (machine types now free-text)
   // Pre-fetch machine types on authenticated layout mount (60min cache)
   // This ensures machine types are cached before any screen needs them
-  useMachineTypes();
+  // useMachineTypes();
 
   // Activate SSE observer for real-time notifications (connects to backend stream)
   // This hook connects SSE client when user is authenticated and disconnects on unmount

--- a/apps/frontend/src/constants/index.ts
+++ b/apps/frontend/src/constants/index.ts
@@ -287,3 +287,6 @@ export type Language = typeof LANGUAGES[keyof typeof LANGUAGES];
 
 // Day of Week labels
 export * from './dayOfWeekLabels';
+
+// Machine Type Suggestions
+export * from './machineTypeSuggestions';

--- a/apps/frontend/src/constants/machineTypeSuggestions.ts
+++ b/apps/frontend/src/constants/machineTypeSuggestions.ts
@@ -1,0 +1,111 @@
+/**
+ * Machine Type Suggestions
+ * 
+ * Lista de tipos de máquina comunes para sugerencias en UI (Combobox/Autocomplete).
+ * 
+ * IMPORTANTE: Esta lista es solo para UX - no limita lo que el usuario puede ingresar.
+ * Los usuarios pueden escribir cualquier tipo personalizado (free-text 2-50 caracteres).
+ * 
+ * Casos de uso:
+ * - Dropdown/Combobox en formulario de registro de máquina
+ * - Autocompletado para agilizar entrada de datos
+ * - Sugerencias en búsqueda/filtrado
+ * 
+ * Estrategia de contenido:
+ * - Incluir tipos más comunes en industria de manejo de materiales
+ * - Mantener nombres en español (mercado principal)
+ * - Ordenar alfabéticamente para fácil localización
+ * - Máximo 10-15 sugerencias (evitar overwhelm)
+ */
+
+export const MACHINE_TYPE_SUGGESTIONS = [
+  'Apisonadora',
+  'Autoelevador',
+  'Carretilla Elevadora',
+  'Excavadora',
+  'Grúa',
+  'Minicargadora',
+  'Montacargas',
+  'Pala Cargadora',
+  'Plataforma Elevadora',
+  'Retroexcavadora',
+  'Tractor',
+  'Transpaleta',
+  'Zorra Hidráulica'
+] as const;
+
+/**
+ * TODO: Feature estratégica - Sugerencias dinámicas basadas en tipos más usados
+ * 
+ * En lugar de lista hardcoded, consultar tipos más frecuentes del usuario/organización.
+ * 
+ * Beneficios:
+ * - Personalización por industria (construcción vs logística)
+ * - Aprende de patrones del usuario
+ * - Reduce fricción en entrada repetitiva
+ * 
+ * Implementación:
+ * - Endpoint: GET /api/v1/machines/type-suggestions?userId={id}&limit=10
+ * - Agregación MongoDB: Agrupar por machineTypeName, contar, ordenar por frecuencia
+ * - Caché en frontend (localStorage o React Query con staleTime largo)
+ * - Fallback a MACHINE_TYPE_SUGGESTIONS si no hay datos
+ * 
+ * Ejemplo query:
+ * ```typescript
+ * const { data: suggestions } = useQuery({
+ *   queryKey: ['machineTypeSuggestions', userId],
+ *   queryFn: () => machineService.getTypeSuggestions(userId),
+ *   staleTime: 1000 * 60 * 60 * 24, // 24 horas
+ *   placeholderData: MACHINE_TYPE_SUGGESTIONS
+ * });
+ * ```
+ */
+
+/**
+ * TODO: Feature estratégica - Sugerencias contextuales por sector
+ * 
+ * Diferentes listas según el sector/industria del usuario.
+ * 
+ * Ejemplo:
+ * ```typescript
+ * export const MACHINE_TYPE_SUGGESTIONS_BY_SECTOR = {
+ *   CONSTRUCTION: ['Excavadora', 'Retroexcavadora', 'Bulldozer', 'Grúa torre'],
+ *   LOGISTICS: ['Autoelevador', 'Transpaleta', 'Apilador', 'Carretilla'],
+ *   AGRICULTURE: ['Tractor', 'Cosechadora', 'Sembradora', 'Pulverizadora'],
+ *   MINING: ['Excavadora minera', 'Camión minero', 'Perforadora', 'Cargador frontal']
+ * } as const;
+ * ```
+ * 
+ * Uso:
+ * ```typescript
+ * const userSector = user.organization?.sector || 'CONSTRUCTION';
+ * const suggestions = MACHINE_TYPE_SUGGESTIONS_BY_SECTOR[userSector] || MACHINE_TYPE_SUGGESTIONS;
+ * ```
+ */
+
+/**
+ * TODO: Feature estratégica - Aliases y búsqueda fuzzy
+ * 
+ * Mapear términos similares/sinónimos para mejorar búsqueda.
+ * 
+ * Ejemplo:
+ * ```typescript
+ * export const MACHINE_TYPE_ALIASES: Record<string, string[]> = {
+ *   'Autoelevador': ['autoelevador', 'elevador', 'forklift', 'montacargas'],
+ *   'Excavadora': ['excavadora', 'pala excavadora', 'excavator', 'retro'],
+ *   'Grúa': ['grua', 'crane', 'grúa torre', 'grúa móvil']
+ * };
+ * ```
+ * 
+ * Búsqueda fuzzy con Fuse.js:
+ * ```typescript
+ * import Fuse from 'fuse.js';
+ * 
+ * const fuse = new Fuse(MACHINE_TYPE_SUGGESTIONS, {
+ *   threshold: 0.3, // Tolerancia a errores de tipeo
+ *   includeScore: true
+ * });
+ * 
+ * const results = fuse.search(userInput); // "exca" → "Excavadora"
+ * ```
+ */

--- a/apps/frontend/src/hooks/index.ts
+++ b/apps/frontend/src/hooks/index.ts
@@ -309,6 +309,9 @@ export { useMachineTypes } from './useMachineTypes';
 // LEGACY: Hooks deprecated after migrating to free-text machineTypeName
 // export { useMachineTypeName, useMachineTypeResolver } from './useMachineTypeName';
 
+// Machines
+export { useMachines, useMachine } from './useMachines';
+
 // Machine registration
 export { useRegistrationConfirmation } from './useRegistrationConfirmation';
 

--- a/apps/frontend/src/hooks/index.ts
+++ b/apps/frontend/src/hooks/index.ts
@@ -306,7 +306,8 @@ export { useBrowserNotification } from './useBrowserNotification';
 
 // Machine types
 export { useMachineTypes } from './useMachineTypes';
-export { useMachineTypeName, useMachineTypeResolver } from './useMachineTypeName';
+// LEGACY: Hooks deprecated after migrating to free-text machineTypeName
+// export { useMachineTypeName, useMachineTypeResolver } from './useMachineTypeName';
 
 // Machine registration
 export { useRegistrationConfirmation } from './useRegistrationConfirmation';

--- a/apps/frontend/src/hooks/useMachineTypeName.ts
+++ b/apps/frontend/src/hooks/useMachineTypeName.ts
@@ -1,61 +1,77 @@
-import { useMemo } from 'react';
-import { useMachineTypes } from './useMachineTypes';
-
-/**
- * Hook to resolve a machine type ID to its display name.
- * 
- * Leverages TanStack Query cache from useMachineTypes (60min staleTime).
- * Returns name or undefined if not found/loading.
- * 
- * @param machineTypeId - Machine type ObjectId to resolve
- * @returns Machine type name or undefined
- * 
- * @example
- * const typeName = useMachineTypeName(machine.machineTypeId);
- * <span>{typeName ?? 'Tipo desconocido'}</span>
- */
-export function useMachineTypeName(machineTypeId: string | undefined): string | undefined {
-  const { data: machineTypes, isLoading } = useMachineTypes();
-  
-  return useMemo(() => {
-    if (!machineTypeId || isLoading || !machineTypes) {
-      return undefined;
-    }
-    
-    return machineTypes.find(type => type.id === machineTypeId)?.name;
-  }, [machineTypeId, machineTypes, isLoading]);
-}
-
-/**
- * Hook to resolve multiple machine type IDs to a Map<id, name>.
- * 
- * Useful for batch lookups (e.g., in lists with many machines).
- * Returns Map with resolved names, empty for loading/not-found.
- * 
- * @param machineTypeIds - Array of machine type IDs to resolve
- * @returns Map of ID -> name
- * 
- * @example
- * const typeNames = useMachineTypeResolver(machines.map(m => m.machineTypeId));
- * machines.map(m => typeNames.get(m.machineTypeId) ?? 'Unknown')
- */
-export function useMachineTypeResolver(machineTypeIds: string[]): Map<string, string> {
-  const { data: machineTypes, isLoading } = useMachineTypes();
-  
-  return useMemo(() => {
-    const result = new Map<string, string>();
-    
-    if (isLoading || !machineTypes) {
-      return result;
-    }
-    
-    machineTypeIds.forEach(id => {
-      const type = machineTypes.find(t => t.id === id);
-      if (type) {
-        result.set(id, type.name);
-      }
-    });
-    
-    return result;
-  }, [machineTypeIds, machineTypes, isLoading]);
-}
+// LEGACY: This file contains deprecated hooks for resolving machineTypeId -> name.
+//
+// STATUS: No longer needed - machineTypeName is now a direct string property.
+//
+// REASON FOR COMMENTING:
+// - Old approach: machine.machineTypeId (ObjectId) -> API lookup -> name
+// - New approach: machine.machineTypeName (string) -> direct display
+//
+// KEPT FOR:
+// - Reference during migration period
+// - Future reuse if dynamic suggestions endpoint is implemented
+//
+// MIGRATION:
+// - All UI components now access machine.machineTypeName directly
+// - No resolver/lookup hooks needed
+//
+// import { useMemo } from 'react';
+// import { useMachineTypes } from './useMachineTypes';
+//
+// /**
+//  * Hook to resolve a machine type ID to its display name.
+//  * 
+//  * Leverages TanStack Query cache from useMachineTypes (60min staleTime).
+//  * Returns name or undefined if not found/loading.
+//  * 
+//  * @param machineTypeId - Machine type ObjectId to resolve
+//  * @returns Machine type name or undefined
+//  * 
+//  * @example
+//  * const typeName = useMachineTypeName(machine.machineTypeId);
+//  * <span>{typeName ?? 'Tipo desconocido'}</span>
+//  */
+// export function useMachineTypeName(machineTypeId: string | undefined): string | undefined {
+//   const { data: machineTypes, isLoading } = useMachineTypes();
+//   
+//   return useMemo(() => {
+//     if (!machineTypeId || isLoading || !machineTypes) {
+//       return undefined;
+//     }
+//     
+//     return machineTypes.find(type => type.id === machineTypeId)?.name;
+//   }, [machineTypeId, machineTypes, isLoading]);
+// }
+//
+// /**
+//  * Hook to resolve multiple machine type IDs to a Map<id, name>.
+//  * 
+//  * Useful for batch lookups (e.g., in lists with many machines).
+//  * Returns Map with resolved names, empty for loading/not-found.
+//  * 
+//  * @param machineTypeIds - Array of machine type IDs to resolve
+//  * @returns Map of ID -> name
+//  * 
+//  * @example
+//  * const typeNames = useMachineTypeResolver(machines.map(m => m.machineTypeId));
+//  * machines.map(m => typeNames.get(m.machineTypeId) ?? 'Unknown')
+//  */
+// export function useMachineTypeResolver(machineTypeIds: string[]): Map<string, string> {
+//   const { data: machineTypes, isLoading } = useMachineTypes();
+//   
+//   return useMemo(() => {
+//     const result = new Map<string, string>();
+//     
+//     if (isLoading || !machineTypes) {
+//       return result;
+//     }
+//     
+//     machineTypeIds.forEach(id => {
+//       const type = machineTypes.find(t => t.id === id);
+//       if (type) {
+//         result.set(id, type.name);
+//       }
+//     });
+//     
+//     return result;
+//   }, [machineTypeIds, machineTypes, isLoading]);
+// }

--- a/apps/frontend/src/hooks/useMachineTypes.ts
+++ b/apps/frontend/src/hooks/useMachineTypes.ts
@@ -4,7 +4,25 @@ import { QUERY_KEYS, STORAGE_KEYS } from '../constants';
 import type { MachineTypeResponse } from '@contracts';
 
 /**
- * Hook to fetch machine types for selects and dropdowns.
+ * LEGACY: Hook to fetch machine types for selects and dropdowns.
+ * 
+ * STATUS: Deprecated - Machine types are now free-text strings (machineTypeName).
+ * 
+ * KEPT FOR:
+ * - Backward compatibility with existing machines (objectId references in DB)
+ * - Future type suggestions/autocomplete from historical data
+ * - Admin panel for managing legacy type catalog
+ * 
+ * NEW APPROACH:
+ * - Machines use free-text machineTypeName field
+ * - UI uses MACHINE_TYPE_SUGGESTIONS constant (apps/frontend/src/constants/machineTypeSuggestions.ts)
+ * - No API call needed for registration/edit forms
+ * 
+ * MIGRATION PATH:
+ * - Existing machines continue to have machineTypeId references
+ * - Backend /machines endpoints accept LEGACY header for ObjectId lookups
+ * - Future: Archive this hook once all clients updated
+ * 
  * Reads optional language from localStorage (STORAGE_KEYS.LANGUAGE).
  */
 export function useMachineTypes() {

--- a/apps/frontend/src/i18n/locales/en.json
+++ b/apps/frontend/src/i18n/locales/en.json
@@ -530,6 +530,7 @@
       },
       "confirmation": {
         "title": "Confirm the information",
+        "description": "Are you sure you want to register this machine with the provided information?",
         "subtitle": "Review all data before registering the machine in the system",
         "basicInfo": "Basic Information",
         "notSelected": "Not selected",

--- a/apps/frontend/src/i18n/locales/es.json
+++ b/apps/frontend/src/i18n/locales/es.json
@@ -532,6 +532,7 @@
       },
       "confirmation": {
         "title": "Confirma la información",
+        "description": "¿Estás seguro de que deseas registrar esta máquina con la información proporcionada?",
         "subtitle": "Revisa todos los datos antes de registrar la máquina en el sistema",
         "basicInfo": "Información Básica",
         "notSelected": "No seleccionado",

--- a/apps/frontend/src/screens/machines/MachineDetailsScreen.tsx
+++ b/apps/frontend/src/screens/machines/MachineDetailsScreen.tsx
@@ -1,5 +1,5 @@
 ﻿import React, { useState } from "react";
-import { useParams, useNavigate } from "react-router-dom";
+import { useParams, useNavigate, Link } from "react-router-dom";
 import {
   Heading1,
   BodyText,
@@ -63,6 +63,17 @@ export const MachineDetailsScreen: React.FC = () => {
 
   return (
     <div className="space-y-6">
+      {/* Breadcrumb */}
+      <div className="flex items-center gap-2 text-sm text-muted-foreground">
+        <Link to="/machines" className="hover:text-foreground">
+          {t('machines.breadcrumb.machines')}
+        </Link>
+        <span>/</span>
+        <span className="text-foreground">
+          {machine ? `${machine.brand}-${machine.modelName}` : '...'}
+        </span>
+      </div>
+
       {/* Hero Section - Image + Main Metadata + Actions */}
       <Card className="overflow-hidden">
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-6 p-3">

--- a/apps/frontend/src/screens/machines/MachineDetailsScreen.tsx
+++ b/apps/frontend/src/screens/machines/MachineDetailsScreen.tsx
@@ -10,7 +10,8 @@ import {
   Heading3,
 } from "@components/ui";
 import { useMachineDetailsViewModel } from "../../viewModels/machines";
-import { useMachineTypeName } from "@hooks";
+// LEGACY: useMachineTypeName no longer needed (machine.machineTypeName is direct string)
+// import { useMachineTypeName } from "@hooks";
 import { useTranslation } from "react-i18next";
 import { Settings, Clock, Package, History, AlarmClock, Pencil, ListCheck } from "lucide-react";
 
@@ -54,8 +55,8 @@ export const MachineDetailsScreen: React.FC = () => {
     useMachineDetailsViewModel(id);
   const [imageError, setImageError] = useState(false);
 
-  // Resolve machine type name
-  const machineTypeName = useMachineTypeName(machine?.machineTypeId);
+  // LEGACY: No longer resolving machineType from API (direct property access)
+  // const machineTypeName = useMachineTypeName(machine?.machineTypeId);
 
   const specs = machine?.specs;
   const location = machine?.location;
@@ -142,10 +143,7 @@ export const MachineDetailsScreen: React.FC = () => {
                     />
                     <InfoItem
                       label={t("machines.hero.machineType")}
-                      value={
-                        machineTypeName ??
-                        (machine.machineTypeId ? "Cargando..." : undefined)
-                      }
+                      value={machine.machineTypeName}
                     />
                     <InfoItem
                       label={t("machines.hero.nickname")}
@@ -370,10 +368,7 @@ export const MachineDetailsScreen: React.FC = () => {
                 />
                 <InfoItem
                   label={t("machines.hero.machineType")}
-                  value={
-                    machineTypeName ??
-                    (machine?.machineTypeId ? "Cargando..." : undefined)
-                  }
+                  value={machine?.machineTypeName}
                 />
                 <InfoItem
                   label={t("machines.hero.nickname")}

--- a/apps/frontend/src/screens/machines/MachineEventsScreen.tsx
+++ b/apps/frontend/src/screens/machines/MachineEventsScreen.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams, Link } from 'react-router-dom';
 import { Heading1, BodyText, Button, Card } from '@components/ui';
 import { Plus, AlertCircle } from 'lucide-react';
 import { useMachineEventsViewModel } from '../../viewModels/machines/useMachineEventsViewModel';
@@ -58,6 +58,15 @@ export function MachineEventsScreen() {
   // ========================
   return (
     <div className="space-y-3 max-w-full overflow-x-hidden">
+      {/* Breadcrumb */}
+      <div className="flex items-center gap-2 text-sm text-muted-foreground">
+        <Link to="/machines" className="hover:text-foreground">{vm.t('machines.breadcrumb.machines')}</Link>
+        <span>/</span>
+        <Link to={`/machines/${machineId}`} className="hover:text-foreground">{vm.data.machineLabel}</Link>
+        <span>/</span>
+        <span className="text-foreground">{vm.t('machines.events.title')}</span>
+      </div>
+
       {/* Header with Stats */}
       <div className="flex flex-col lg:flex-row justify-between items-start lg:items-end gap-4">
         <div> 

--- a/apps/frontend/src/screens/machines/MachinesScreen.tsx
+++ b/apps/frontend/src/screens/machines/MachinesScreen.tsx
@@ -3,7 +3,8 @@ import { useNavigate } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { Heading1, BodyText, Button, Card, CardContent, CardHeader, CardTitle } from "@components/ui";
 import { useMachinesViewModel } from "../../viewModels/machines";
-import { useMachineTypeResolver } from "@hooks";
+// LEGACY: useMachineTypeResolver no longer needed (machine.machineTypeName is direct string)
+// import { useMachineTypeResolver } from "@hooks";
 import { ROUTES } from "@constants/index";
 
 const statusVariants: Record<string, string> = {
@@ -24,9 +25,9 @@ export const MachinesScreen: React.FC = () => {
   const { t } = useTranslation();
   const { machines, isLoading, isError, errorMessage, refetch } = useMachinesViewModel();
   
-  // Resolve machine type IDs to names efficiently (batch lookup)
-  const machineTypeIds = machines.map(m => m.machineTypeId);
-  const machineTypeNames = useMachineTypeResolver(machineTypeIds);
+  // LEGACY: No longer resolving machineTypes in batch (direct property access)
+  // const machineTypeIds = machines.map(m => m.machineTypeId);
+  // const machineTypeNames = useMachineTypeResolver(machineTypeIds);
 
   return (
     <div className="space-y-8">
@@ -97,7 +98,7 @@ export const MachinesScreen: React.FC = () => {
               </div>
               <div className="flex justify-between">
                 <span className="text-muted-foreground">{t('machines.list.type')}</span>
-                <span className="text-foreground">{machineTypeNames.get(machine.machineTypeId) ?? t('machines.list.loading')}</span>
+                <span className="text-foreground">{machine.machineTypeName ?? t('common.notSpecified')}</span>
               </div>
               <div className="text-right">
                 <Button variant="outline" size="sm" onPress={() => navigate(`/machines/${machine.id}`)}>
@@ -147,7 +148,7 @@ export const MachinesScreen: React.FC = () => {
                 <div className="text-foreground">{machine.brand}</div>
                 <div className="text-foreground">{machine.modelName}</div>
                 <div className="text-foreground font-mono">{machine.serialNumber}</div>
-                <div className="text-foreground">{machineTypeNames.get(machine.machineTypeId) ?? t('machines.list.loading')}</div>
+                <div className="text-foreground">{machine.machineTypeName ?? t('common.notSpecified')}</div>
                 <div>
                   <StatusPill status={machine.status} />
                 </div>

--- a/apps/frontend/src/screens/machines/machine-edit/steps/BasicInfoStepEdit.tsx
+++ b/apps/frontend/src/screens/machines/machine-edit/steps/BasicInfoStepEdit.tsx
@@ -5,7 +5,7 @@ import { BasicInfoStep } from '../../machine-registration/steps/BasicInfoStep';
  * BasicInfoStepEdit - Wrapper for BasicInfoStep in edit mode
  * 
  * This wrapper passes isEditMode=true to BasicInfoStep to disable
- * immutable fields (serialNumber, machineTypeId)
+ * immutable fields (serialNumber remains immutable; machineTypeName is editable)
  */
 export function BasicInfoStepEdit(props: any) {
   return <BasicInfoStep {...props} isEditMode={true} />;

--- a/apps/frontend/src/screens/machines/machine-edit/steps/ConfirmationStepEdit.tsx
+++ b/apps/frontend/src/screens/machines/machine-edit/steps/ConfirmationStepEdit.tsx
@@ -3,7 +3,8 @@ import { useFormContext, useWatch } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 import { Card, CardContent, CardHeader, CardTitle, ImagePickerField } from '../../../../components/ui';
 import { MachineRegistrationData } from '@contracts';
-import { useMachineTypes } from '@hooks';
+// LEGACY: useMachineTypes no longer needed (machineTypeName is free-text)
+// import { useMachineTypes } from '@hooks';
 import { useMachineEditContext } from '../MachineEditContext';
 
 /**
@@ -22,10 +23,12 @@ export function ConfirmationStepEdit() {
   // Watch all form values for real-time updates
   const data = useWatch({ control });
   const { basicInfo, technicalSpecs } = data;
-  const { data: machineTypes } = useMachineTypes();
-  const selectedMachineTypeName = machineTypes?.find(
-    (type) => type.id === basicInfo?.machineTypeId
-  )?.name;
+  
+  // LEGACY: No longer resolving machineType from API (direct string display)
+  // const { data: machineTypes } = useMachineTypes();
+  // const selectedMachineTypeName = machineTypes?.find(
+  //   (type) => type.id === basicInfo?.machineTypeId
+  // )?.name;
 
   // Helper para mostrar valores con fallback
   const displayValue = (value: any, fallback?: string) => {
@@ -86,9 +89,7 @@ export function ConfirmationStepEdit() {
             <div>
               <dt className="text-sm font-medium text-muted-foreground">Tipo de máquina</dt>
               <dd className="text-sm text-foreground">
-                {selectedMachineTypeName
-                  ? selectedMachineTypeName
-                  : displayValue(basicInfo?.machineTypeId, 'No seleccionado')}
+                {displayValue(basicInfo?.machineTypeName, 'No seleccionado')}
               </dd>
             </div>
             <div>

--- a/apps/frontend/src/screens/machines/machine-registration/MachineRegistrationScreen.tsx
+++ b/apps/frontend/src/screens/machines/machine-registration/MachineRegistrationScreen.tsx
@@ -6,8 +6,11 @@ import { useMachineRegistrationViewModel } from "../../../viewModels/machines/Ma
 import { MachineRegistrationProvider } from "./MachineRegistrationContext";
 import { useRegistrationConfirmation } from "../../../hooks/useRegistrationConfirmation";
 import { MachineRegistrationData } from "@contracts";
+// LEGACY: Skeleton import no longer needed (removed machineTypes loading UI)
+// import { Button } from "../../../components/ui/Button";
+// import { TextBlock, Skeleton } from "@components/ui";
 import { Button } from "../../../components/ui/Button";
-import { TextBlock, Skeleton } from "@components/ui";
+import { TextBlock } from "@components/ui";
 
 /**
  * Pantalla principal para el registro de máquinas usando wizard multi-step + React Hook Form
@@ -25,11 +28,11 @@ export function MachineRegistrationScreen() {
     isLoading,
     handleWizardSubmit,
     handleCancel,
-    // Machine types provided by the ViewModel
-    machineTypeList,
-    machineTypesLoading,
-    machineTypesError,
-    refetchMachineTypes,
+    // LEGACY: Machine types no longer fetched from API (free-text entry)
+    // machineTypeList,
+    // machineTypesLoading,
+    // machineTypesError,
+    // refetchMachineTypes,
   } = viewModel;
 
   /**
@@ -54,39 +57,9 @@ export function MachineRegistrationScreen() {
         </TextBlock>
       </div>
 
-      {/* If machine types are loading, render a full-form skeleton to reflect the whole structure */}
-      {machineTypesLoading && (!machineTypeList || (Array.isArray(machineTypeList) && machineTypeList.length === 0)) && (
-        <div className="shadow-lg rounded-lg p-6">
-          <div className="space-y-6">
-            <div className="h-8 w-1/3"><Skeleton className="h-8 w-full" /></div>
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-              <Skeleton className="h-10 w-full" />
-              <Skeleton className="h-10 w-full" />
-              <Skeleton className="h-10 w-full md:col-span-2" />
-              <Skeleton className="h-24 w-full md:col-span-2" />
-            </div>
-            <div className="flex justify-end space-x-2">
-              <Skeleton className="h-10 w-32" />
-              <Skeleton className="h-10 w-32" />
-            </div>
-          </div>
-        </div>
-      )}
+      {/* LEGACY: Removed machine types loading skeleton (no longer needed for free-text entry) */}
 
-      {/* If machine types failed to load, show error + retry */}
-      {machineTypesError && (
-        <div className="mb-6 bg-yellow-50 border border-yellow-200 rounded-md p-4">
-          <div className="flex items-center justify-between">
-            <div>
-              <h3 className="text-sm font-medium text-yellow-800">{t('machines.registration.screen.loadError')}</h3>
-              <p className="mt-1 text-sm text-yellow-700">{t('machines.registration.screen.loadErrorDescription')}</p>
-            </div>
-            <div>
-              <Button onPress={() => refetchMachineTypes()} className="ml-4">{t('machines.registration.screen.retry')}</Button>
-            </div>
-          </div>
-        </div>
-      )}
+      {/* LEGACY: Removed machine types error banner (no API call to fail) */}
 
       {/* RHF Error Display */}
       {form.formState.errors.root && (
@@ -110,26 +83,24 @@ export function MachineRegistrationScreen() {
       )}
 
       {/* FormProvider wraps the entire wizard for RHF context */}
-      {!machineTypesLoading && !machineTypesError && (
-        <MachineRegistrationProvider viewModel={viewModel}>
-          <FormProvider {...form}>
-            <Wizard<MachineRegistrationData>
-              steps={wizardSteps}
-              initialData={form.getValues()}
-              onSubmit={handleSubmitWithConfirmation}
-              onStepChange={() => {
-                // Force wizard to re-read form values from RHF
-                forceUpdate();
-              }}
-              isSubmitting={isLoading}
-              onCancel={handleCancel}
-              timerLabel={t('machines.registration.verificationTime')}
-              className="bg-white shadow-lg rounded-lg"
-              showProgress
-            />
-          </FormProvider>
-        </MachineRegistrationProvider>
-      )}
+      <MachineRegistrationProvider viewModel={viewModel}>
+        <FormProvider {...form}>
+          <Wizard<MachineRegistrationData>
+            steps={wizardSteps}
+            initialData={form.getValues()}
+            onSubmit={handleSubmitWithConfirmation}
+            onStepChange={() => {
+              // Force wizard to re-read form values from RHF
+              forceUpdate();
+            }}
+            isSubmitting={isLoading}
+            onCancel={handleCancel}
+            timerLabel={t('machines.registration.verificationTime')}
+            className="bg-white shadow-lg rounded-lg"
+            showProgress
+          />
+        </FormProvider>
+      </MachineRegistrationProvider>
     </div>
   );
 }

--- a/apps/frontend/src/screens/machines/machine-registration/steps/BasicInfoStep.tsx
+++ b/apps/frontend/src/screens/machines/machine-registration/steps/BasicInfoStep.tsx
@@ -123,16 +123,18 @@ export function BasicInfoStep({ isEditMode = false, ...wizardProps }: BasicInfoS
         <Controller
           control={control}
           name="basicInfo.machineTypeName"
-          render={({ field: { onChange, value } }) => (
+          render={({ field: { onChange, onBlur, value } }) => (
             <>
               <InputField
                 label={t('machines.registration.basicInfo.machineType')}
                 required
                 value={value || ''}
                 onChangeText={onChange}
+                onBlur={onBlur}
                 placeholder={t('machines.registration.basicInfo.machineTypePlaceholder')}
                 error={errors.basicInfo?.machineTypeName?.message}
                 list="machine-type-suggestions"
+                autoComplete="off"
                 // disabled={isEditMode} // TODO: Uncomment if machineTypeName should be immutable
                 // helperText={isEditMode ? t('machines.registration.basicInfo.machineTypeImmutable') : undefined}
               />

--- a/apps/frontend/src/screens/machines/machine-registration/steps/BasicInfoStep.tsx
+++ b/apps/frontend/src/screens/machines/machine-registration/steps/BasicInfoStep.tsx
@@ -1,9 +1,11 @@
-import React, { useMemo } from 'react';
+import React from 'react';
 import { useFormContext, Controller } from 'react-hook-form';
 import { useTranslation, Trans } from 'react-i18next';
-import { InputField, Select, Textarea, Skeleton, BodyText } from '../../../../components/ui';
+import { InputField, Textarea, Skeleton, BodyText } from '../../../../components/ui';
 import { MachineRegistrationData } from '@contracts';
-import { useMachineTypes } from '@hooks';
+// LEGACY: useMachineTypes no longer needed (free-text machineTypeName)
+// import { useMachineTypes } from '@hooks';
+import { MACHINE_TYPE_SUGGESTIONS } from '@constants';
 import { WizardStepProps } from '../../../../components/forms/wizard';
 
 /**
@@ -28,13 +30,12 @@ export function BasicInfoStep({ isEditMode = false, ...wizardProps }: BasicInfoS
   const { t } = useTranslation();
 
   // Mock data para machine types (en producción vendría del ViewModel/API)
-  const { data: machineTypeList, isLoading, isError } = useMachineTypes();
-
-  // Memoize machineTypes transformation to prevent infinite re-renders
-  const machineTypes = useMemo(() => {
-    if (!Array.isArray(machineTypeList)) return [];
-    return machineTypeList.map((mt: any) => ({ value: mt.id, label: mt.name }));
-  }, [machineTypeList]);
+  // LEGACY: No longer fetching machineTypes from API (free-text entry)
+  // const { data: machineTypeList, isLoading, isError } = useMachineTypes();
+  // const machineTypes = useMemo(() => {
+  //   if (!Array.isArray(machineTypeList)) return [];
+  //   return machineTypeList.map((mt: any) => ({ value: mt.id, label: mt.name }));
+  // }, [machineTypeList]);
 
   return (
     <div className="space-y-6">
@@ -113,31 +114,34 @@ export function BasicInfoStep({ isEditMode = false, ...wizardProps }: BasicInfoS
         </div>
         
         {/* Tipo de máquina */}
-        {/* BUSINESS DECISION: machineTypeId IS editable in edit mode (unlike serialNumber)
+        {/* BUSINESS DECISION: machineTypeName IS editable in edit mode (unlike serialNumber)
             Rationale: Machines may need reclassification (e.g., specialized excavator → standard excavator)
-            Backend validates that the new machineTypeId exists before persisting.
-            Alternative consideration: If machineTypeId should be immutable (like serialNumber),
+            Free-text entry allows custom types not in suggestions.
+            Alternative consideration: If machineTypeName should be immutable (like serialNumber),
             add disabled={isEditMode} prop and helperText explaining it cannot be changed.
         */}
         <Controller
           control={control}
-          name="basicInfo.machineTypeId"
+          name="basicInfo.machineTypeName"
           render={({ field: { onChange, value } }) => (
-            isLoading ? (
-              <Skeleton className="h-10 w-full" />
-            ) : (
-              <Select
+            <>
+              <InputField
                 label={t('machines.registration.basicInfo.machineType')}
                 required
                 value={value || ''}
-                onValueChange={onChange}
-                options={machineTypes}
-                placeholder={isError ? t('machines.registration.basicInfo.machineTypeError') : t('machines.registration.basicInfo.machineTypePlaceholder')}
-                error={errors.basicInfo?.machineTypeId?.message}
-                // disabled={isEditMode} // TODO: Uncomment if machineTypeId should be immutable
+                onChangeText={onChange}
+                placeholder={t('machines.registration.basicInfo.machineTypePlaceholder')}
+                error={errors.basicInfo?.machineTypeName?.message}
+                list="machine-type-suggestions"
+                // disabled={isEditMode} // TODO: Uncomment if machineTypeName should be immutable
                 // helperText={isEditMode ? t('machines.registration.basicInfo.machineTypeImmutable') : undefined}
               />
-            )
+              <datalist id="machine-type-suggestions">
+                {MACHINE_TYPE_SUGGESTIONS.map((type) => (
+                  <option key={type} value={type} />
+                ))}
+              </datalist>
+            </>
           )}
         />
         

--- a/apps/frontend/src/screens/machines/machine-registration/steps/ConfirmationStep.tsx
+++ b/apps/frontend/src/screens/machines/machine-registration/steps/ConfirmationStep.tsx
@@ -3,7 +3,8 @@ import { useFormContext, useWatch } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 import { Card, CardContent, CardHeader, CardTitle, ImagePickerField } from '../../../../components/ui';
 import { MachineRegistrationData } from '@contracts';
-import { useMachineTypes } from '@hooks';
+// LEGACY: useMachineTypes no longer needed (machineTypeName is free-text)
+// import { useMachineTypes } from '@hooks';
 import { useMachineRegistrationContext } from '../MachineRegistrationContext';
 
 /**
@@ -23,10 +24,12 @@ export function ConfirmationStep() {
   // Watch all form values for real-time updates
   const data = useWatch({ control });
   const { basicInfo, technicalSpecs, addPhotoLater } = data;
-  const { data: machineTypes } = useMachineTypes();
-  const selectedMachineTypeName = machineTypes?.find(
-    (type) => type.id === basicInfo?.machineTypeId
-  )?.name;
+  
+  // LEGACY: No longer resolving machineType from API (direct string display)
+  // const { data: machineTypes } = useMachineTypes();
+  // const selectedMachineTypeName = machineTypes?.find(
+  //   (type) => type.id === basicInfo?.machineTypeId
+  // )?.name;
 
   // Helper para mostrar valores con fallback
   const displayValue = (value: any, fallback?: string) => {
@@ -85,9 +88,7 @@ export function ConfirmationStep() {
             <div>
               <dt className="text-sm font-medium text-muted-foreground">{t('machines.registration.basicInfo.machineType')}</dt>
               <dd className="text-sm text-foreground">
-                {selectedMachineTypeName
-                  ? selectedMachineTypeName
-                  : displayValue(basicInfo?.machineTypeId, t('machines.registration.confirmation.notSelected'))}
+                {displayValue(basicInfo?.machineTypeName, t('machines.registration.confirmation.notSelected'))}
               </dd>
             </div>
             <div>

--- a/apps/frontend/src/screens/maintenance/MaintenanceAlarmsListScreen.tsx
+++ b/apps/frontend/src/screens/maintenance/MaintenanceAlarmsListScreen.tsx
@@ -99,7 +99,7 @@ export function MaintenanceAlarmsListScreen() {
           </Link>
           <span>/</span>
           <Link to={`/machines/${machineId}`} className="hover:text-foreground">
-            {vm.t('machines.breadcrumb.detail')}
+            {vm.data.machineLabel}
           </Link>
           <span>/</span>
           <span className="text-foreground">{vm.t('machines.breadcrumb.alarms')}</span>
@@ -153,7 +153,7 @@ export function MaintenanceAlarmsListScreen() {
           </Link>
           <span>/</span>
           <Link to={`/machines/${machineId}`} className="hover:text-foreground">
-            {vm.t('machines.breadcrumb.detail')}
+            {vm.data.machineLabel}
           </Link>
           <span>/</span>
           <span className="text-foreground">{vm.t('machines.breadcrumb.alarms')}</span>

--- a/apps/frontend/src/screens/quickcheck/QuickCheckHistoryScreen.tsx
+++ b/apps/frontend/src/screens/quickcheck/QuickCheckHistoryScreen.tsx
@@ -48,7 +48,7 @@ export const QuickCheckHistoryScreen: React.FC = () => {
           </Link>
           <span>/</span>
           <Link to={vm.paths.machineDetail} className="hover:text-foreground">
-            {t('quickchecks.history.breadcrumbs.detail')}
+            {vm.machineLabel}
           </Link>
           <span>/</span>
           <Link to={vm.paths.quickCheck} className="hover:text-foreground">

--- a/apps/frontend/src/screens/quickcheck/QuickCheckScreen.tsx
+++ b/apps/frontend/src/screens/quickcheck/QuickCheckScreen.tsx
@@ -106,7 +106,7 @@ export const QuickCheckScreen: React.FC = () => {
         <div className="flex items-center gap-2 text-sm text-muted-foreground mb-2">
           <Link to="/machines" className="hover:text-foreground">{t('quickchecks.screen.breadcrumbs.machines')}</Link>
           <span>/</span>
-          <Link to={`/machines/${machineId}`} className="hover:text-foreground">{t('quickchecks.screen.breadcrumbs.detail')}</Link>
+          <Link to={`/machines/${machineId}`} className="hover:text-foreground">{vm.machineLabel}</Link>
           <span>/</span>
           <span className="text-foreground">{t('quickchecks.screen.breadcrumbs.quickcheck')}</span>
         </div>

--- a/apps/frontend/src/services/api/machineService.ts
+++ b/apps/frontend/src/services/api/machineService.ts
@@ -166,7 +166,30 @@ export class MachineService {
     return handleApiResponse(response);
   }
 
-  // Get machine types (for dropdowns etc.)
+  /**
+   * LEGACY: Get machine types (for dropdowns etc.)
+   * 
+   * STATUS: Deprecated - Machine types are now free-text strings (machineTypeName).
+   * 
+   * KEPT FOR:
+   * - Backward compatibility with existing machines (objectId references in DB)
+   * - Admin panel for managing legacy type catalog
+   * - Future type suggestions/autocomplete from historical data
+   * 
+   * NEW APPROACH:
+   * - Machines use free-text machineTypeName field
+   * - UI uses MACHINE_TYPE_SUGGESTIONS constant
+   * - No API call needed for registration/edit forms
+   * 
+   * MIGRATION PATH:
+   * - Existing machines continue to have machineTypeId references
+   * - Backend /machines endpoints accept LEGACY header for ObjectId lookups
+   * - Backend /machine-types endpoints remain functional for admin/legacy purposes
+   * - This method will be archived once all clients updated
+   * 
+   * @param language - Optional language for i18n type names
+   * @returns Array of machine type objects with id and name
+   */
   async getMachineTypes(language?: string): Promise<MachineTypeResponse[]> {
     const params: Record<string, string> = {};
     if (language) params.language = language;

--- a/apps/frontend/src/viewModels/machines/MachineEditViewModel.ts
+++ b/apps/frontend/src/viewModels/machines/MachineEditViewModel.ts
@@ -13,7 +13,8 @@ import { TechnicalSpecsStep } from '../../screens/machines/machine-registration/
 import { PhotoStepEdit, BasicInfoStepEdit, ConfirmationStepEdit } from '../../screens/machines/machine-edit/steps';
 import { useZodForm } from '../../hooks/useZodForm';
 import { useMachine, useUpdateMachine } from '../../hooks/useMachines';
-import { useMachineTypes } from '../../hooks';
+// LEGACY: useMachineTypes no longer needed (free-text machineTypeName)
+// import { useMachineTypes } from '../../hooks';
 import type { MachineTypeResponse } from '@contracts';
 import { toast } from '@components/ui';
 import { modal } from '@helpers/modal';
@@ -58,11 +59,12 @@ export interface MachineEditViewModel {
   handleCancel: () => void;
   reset: () => void;
   
-  // Machine types data (for selects)
-  machineTypeList?: MachineTypeResponse[];
-  machineTypesLoading: boolean;
-  machineTypesError: boolean;
-  refetchMachineTypes: () => Promise<unknown> | void;
+  // LEGACY: Machine types no longer used (free-text machineTypeName)
+  // Users can type any machine type directly in the form
+  // machineTypeList?: MachineTypeResponse[];
+  // machineTypesLoading: boolean;
+  // machineTypesError: boolean;
+  // refetchMachineTypes: () => Promise<unknown> | void;
 }
 
 /**
@@ -187,7 +189,7 @@ export function useMachineEditViewModel(machineId: string): MachineEditViewModel
         const hasRequiredValues = basicInfo?.serialNumber?.trim() && 
                                   basicInfo?.brand?.trim() && 
                                   basicInfo?.modelName?.trim() && 
-                                  basicInfo?.machineTypeId?.trim() && 
+                                  basicInfo?.machineTypeName?.trim() && // NEW: Free-text field
                                   basicInfo?.name?.trim();
         
         return !hasErrors && !!hasRequiredValues;
@@ -227,13 +229,13 @@ export function useMachineEditViewModel(machineId: string): MachineEditViewModel
   // Nota: form no necesita estar en dependencias - las funciones isValid capturan form por closure
   // Si form estuviera en deps, wizardSteps se recrearía en cada form change, causando loops infinitos
 
-  // Fetch machine types (for dropdown in BasicInfoStep)
-  const {
-    data: machineTypeList,
-    isLoading: machineTypesLoading,
-    isError: machineTypesError,
-    refetch: refetchMachineTypes,
-  } = useMachineTypes();
+  // LEGACY: Machine types fetch removed (free-text machineTypeName)
+  // const {
+  //   data: machineTypeList,
+  //   isLoading: machineTypesLoading,
+  //   isError: machineTypesError,
+  //   refetch: refetchMachineTypes,
+  // } = useMachineTypes();
 
   /**
    * Handle wizard submit - main business logic for UPDATE
@@ -425,11 +427,11 @@ export function useMachineEditViewModel(machineId: string): MachineEditViewModel
     // Machine data
     machine,
     
-    // Machine types from hook
-    machineTypeList,
-    machineTypesLoading,
-    machineTypesError,
-    refetchMachineTypes,
+    // LEGACY: Machine types removed (free-text machineTypeName)
+    // machineTypeList,
+    // machineTypesLoading,
+    // machineTypesError,
+    // refetchMachineTypes,
     
     // Actions
     handleWizardSubmit,
@@ -446,13 +448,14 @@ export function useMachineEditViewModel(machineId: string): MachineEditViewModel
     existingPhotoUrl,
     shouldRemovePhoto,
     machine,
-    machineTypeList,
-    machineTypesLoading,
-    machineTypesError,
+    // LEGACY: machineTypes removed (free-text machineTypeName)
+    // machineTypeList,
+    // machineTypesLoading,
+    // machineTypesError,
     handleWizardSubmit,
     handleCancel,
     reset,
-    // Nota: setPhotoFile, setShouldRemovePhoto, refetchMachineTypes son funciones
+    // Nota: setPhotoFile, setShouldRemovePhoto son funciones
     // estables que no cambian, no necesitan estar en dependencias
   ]);
 }
@@ -469,7 +472,7 @@ function mapMachineToWizardData(machine: CreateMachineResponse): MachineRegistra
       serialNumber: machine.serialNumber,
       brand: machine.brand,
       modelName: machine.modelName,
-      machineTypeId: machine.machineTypeId,
+      machineTypeName: machine.machineTypeName, // NEW: Free-text field
       name: machine.nickname || `${machine.brand} ${machine.modelName}`,
       description: '', // Not stored in backend currently
       nickname: machine.nickname || '',
@@ -507,7 +510,7 @@ function mapWizardDataToUpdateRequest(wizardData: MachineRegistrationData): Upda
     brand: wizardData.basicInfo.brand,
     modelName: wizardData.basicInfo.modelName,
     nickname: wizardData.basicInfo.name,
-    machineTypeId: wizardData.basicInfo.machineTypeId,
+    machineTypeName: wizardData.basicInfo.machineTypeName, // NEW: Free-text field
     
     // Assignment
     assignedTo: wizardData.technicalSpecs.assignedTo,

--- a/apps/frontend/src/viewModels/machines/MachineRegistrationViewModel.ts
+++ b/apps/frontend/src/viewModels/machines/MachineRegistrationViewModel.ts
@@ -15,7 +15,8 @@ import { useAuthStore } from '../../store/slices/authSlice';
 import { WizardStep } from '../../components/forms/wizard';
 import { BasicInfoStep, PhotoStep, TechnicalSpecsStep, ConfirmationStep } from '../../screens/machines/machine-registration/steps';
 import { useZodForm } from '../../hooks/useZodForm';
-import { useMachineTypes } from '../../hooks';
+// LEGACY: useMachineTypes no longer needed (free-text machineTypeName)
+// import { useMachineTypes } from '../../hooks';
 import type { MachineTypeResponse } from '@contracts';
 import { toast } from '@components/ui';
 import { useNavigate } from 'react-router-dom';
@@ -59,11 +60,13 @@ export interface MachineRegistrationViewModel {
   handleWizardSubmit: (_wizardData: MachineRegistrationData) => Promise<void>;
   handleCancel: () => void;
   reset: () => void;
-  // Machine types data (for selects)
-  machineTypeList?: MachineTypeResponse[];
-  machineTypesLoading: boolean;
-  machineTypesError: boolean;
-  refetchMachineTypes: () => Promise<unknown> | void;
+  
+  // LEGACY: Machine types no longer used (free-text machineTypeName)
+  // Users can type any machine type directly in the form
+  // machineTypeList?: MachineTypeResponse[];
+  // machineTypesLoading: boolean;
+  // machineTypesError: boolean;
+  // refetchMachineTypes: () => Promise<unknown> | void;
 }
 
 /**
@@ -387,11 +390,11 @@ export function useMachineRegistrationViewModel(): MachineRegistrationViewModel 
     photoFile,
     setPhotoFile,
     
-    // Machine types from hook
-    machineTypeList,
-    machineTypesLoading,
-    machineTypesError,
-    refetchMachineTypes,
+    // LEGACY: Machine types removed (free-text machineTypeName)
+    // machineTypeList,
+    // machineTypesLoading,
+    // machineTypesError,
+    // refetchMachineTypes,
     
     // Actions
     handleWizardSubmit,
@@ -418,7 +421,7 @@ function mapWizardDataToDomain(wizardData: MachineRegistrationData): CreateMachi
     serialNumber: wizardData.basicInfo.serialNumber,
     brand: wizardData.basicInfo.brand,
     modelName: wizardData.basicInfo.modelName,
-    machineTypeId: wizardData.basicInfo.machineTypeId,
+    machineTypeName: wizardData.basicInfo.machineTypeName, // NEW: Free-text field
     ownerId: wizardData.basicInfo.ownerId || currentUserId,
     createdById: wizardData.basicInfo.createdById || currentUserId,
     specs: {

--- a/apps/frontend/src/viewModels/machines/MachineRegistrationViewModel.ts
+++ b/apps/frontend/src/viewModels/machines/MachineRegistrationViewModel.ts
@@ -150,7 +150,7 @@ export function useMachineRegistrationViewModel(): MachineRegistrationViewModel 
         const hasRequiredValues = basicInfo?.serialNumber?.trim() && 
                                   basicInfo?.brand?.trim() && 
                                   basicInfo?.modelName?.trim() && 
-                                  basicInfo?.machineTypeId?.trim() && 
+                                  basicInfo?.machineTypeName?.trim() && 
                                   basicInfo?.name?.trim();
         
         // 3. Both conditions must be met
@@ -195,13 +195,13 @@ export function useMachineRegistrationViewModel(): MachineRegistrationViewModel 
     },
   ];
 
-  // Fetch machine types (moved to ViewModel to keep screen presentational)
-  const {
-    data: machineTypeList,
-    isLoading: machineTypesLoading,
-    isError: machineTypesError,
-    refetch: refetchMachineTypes,
-  } = useMachineTypes();
+  // LEGACY: No longer fetching machineTypes from API (free-text entry)
+  // const {
+  //   data: machineTypeList,
+  //   isLoading: machineTypesLoading,
+  //   isError: machineTypesError,
+  //   refetch: refetchMachineTypes,
+  // } = useMachineTypes();
 
   /**
    * Handle wizard submit - main business logic

--- a/apps/frontend/src/viewModels/machines/useMachineEventsViewModel.ts
+++ b/apps/frontend/src/viewModels/machines/useMachineEventsViewModel.ts
@@ -7,6 +7,7 @@ import {
   useCreateEventType,
 } from '@hooks/useMachineEvents';
 import { useDebounce } from '@hooks/useDebounce';
+import { useMachine } from '@hooks';
 import type { MachineEvent, GetEventsQuery } from '@services/api/machineEventService';
 
 /**
@@ -55,6 +56,10 @@ import type { MachineEvent, GetEventsQuery } from '@services/api/machineEventSer
  */
 export function useMachineEventsViewModel(machineId: string | undefined) {
   const { t } = useTranslation();
+
+  // Machine data for breadcrumb label
+  const { data: machineData } = useMachine(machineId ?? '');
+  const machineLabel = machineData ? `${machineData.brand}-${machineData.modelName}` : '...';
 
   // ========================
   // STATE MANAGEMENT
@@ -510,6 +515,7 @@ export function useMachineEventsViewModel(machineId: string | undefined) {
       // eventsByType: Map<string, number> - Distribución por tipo
       // eventsByMonth: Array<{month: string, count: number}> - Timeline
       // topEventTypes: Array<{typeId: string, name: string, count: number}> - Top 5
+      machineLabel,
     },
     
     // Actions

--- a/apps/frontend/src/viewModels/machines/useQuickCheckHistoryViewModel.ts
+++ b/apps/frontend/src/viewModels/machines/useQuickCheckHistoryViewModel.ts
@@ -3,6 +3,7 @@ import { useQuery } from '@tanstack/react-query';
 import { quickCheckService } from '@services/api/quickCheckService';
 import { QUERY_KEYS } from '@constants';
 import { useAuth } from '@store/AuthProvider';
+import { useMachine } from '@hooks';
 import type { IQuickCheckRecord, IQuickCheckItem } from '@domain';
 
 /**
@@ -33,6 +34,10 @@ export function useQuickCheckHistoryViewModel() {
     enabled: !!machineId,
   });
   console.log("data fetch", data);
+
+  // ===== Machine data for breadcrumb =====
+  const { data: machineData } = useMachine(machineId || '');
+  const machineLabel = machineData ? `${machineData.brand}-${machineData.modelName}` : '...';
 
   // ===== Computed values =====
   const records = data?.quickChecks || [];
@@ -134,6 +139,7 @@ export function useQuickCheckHistoryViewModel() {
   return {
     // Data
     machineId,
+    machineLabel,
     records,
     hasRecords,
     totalRecords,

--- a/apps/frontend/src/viewModels/machines/useQuickCheckViewModel.ts
+++ b/apps/frontend/src/viewModels/machines/useQuickCheckViewModel.ts
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback, useMemo } from 'react';
 import { useParams, useLocation } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { toast } from '@components/ui';
+import { useMachine } from '@hooks';
 import type {
   QuickCheckItemUI,
   QuickCheckItemInput,
@@ -36,6 +37,10 @@ export function useQuickCheckViewModel() {
   if (!machineId) {
     throw new Error('Machine ID is required');
   }
+
+  // Machine data for breadcrumb label
+  const { data: machineData } = useMachine(machineId);
+  const machineLabel = machineData ? `${machineData.brand}-${machineData.modelName}` : '...';
 
   // ===== State =====
   const [mode, setMode] = useState<QuickCheckMode>('EDITING');
@@ -363,6 +368,7 @@ export function useQuickCheckViewModel() {
   return {
     // Machine context
     machineId,
+    machineLabel,
 
     // UI State
     mode,

--- a/apps/frontend/src/viewModels/maintenance/useMaintenanceAlarmsViewModel.ts
+++ b/apps/frontend/src/viewModels/maintenance/useMaintenanceAlarmsViewModel.ts
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useMaintenanceAlarms, useDeleteMaintenanceAlarm } from '@hooks';
+import { useMaintenanceAlarms, useDeleteMaintenanceAlarm, useMachine } from '@hooks';
 import { useToast } from '@hooks/useToast';
 import type { MaintenanceAlarm } from '@contracts';
 
@@ -67,6 +67,9 @@ export function useMaintenanceAlarmsViewModel(machineId: string | undefined) {
     false // Get all alarms (no filter by active)
   );
 
+  // Fetch machine data for breadcrumb label
+  const { data: machineData } = useMachine(machineId ?? '');
+
   // Delete mutation
   const deleteMutation = useDeleteMaintenanceAlarm(machineId);
 
@@ -76,6 +79,12 @@ export function useMaintenanceAlarmsViewModel(machineId: string | undefined) {
   
   const alarms = data?.alarms || [];
   const isEmpty = alarms.length === 0;
+  
+  // Breadcrumb label: "{Brand}-{ModelName}" (e.g. "Toyota-FD40")
+  // Falls back to '...' while machine data loads
+  const machineLabel = machineData
+    ? `${machineData.brand}-${machineData.modelName}`
+    : '...';
   
   // TODO Sprint #12: Get from machine data instead of mock
   // This will come from machine.specs.operatingHours when we have machine context
@@ -180,6 +189,7 @@ export function useMaintenanceAlarmsViewModel(machineId: string | undefined) {
       currentOperatingHours,
       total: data?.total || 0,
       activeCount: data?.activeCount || 0,
+      machineLabel,
     },
     
     // MODALS: State for create/edit and detail modals

--- a/packages/contracts/src/dashboard.contract.ts
+++ b/packages/contracts/src/dashboard.contract.ts
@@ -33,7 +33,7 @@ export const RecentQuickCheckDTOSchema = z.object({
     //   id: z.string(),
     //   name: z.string()
     // }).optional()
-    machineTypeName: z.string()
+    machineTypeName: z.string().optional() // Optional: legacy/unmigrated machines may not have it yet
   })
 });
 
@@ -73,7 +73,7 @@ export const RecentMachineEventDTOSchema = z.object({
     //   id: z.string(),
     //   name: z.string()
     // }).optional()
-    machineTypeName: z.string()
+    machineTypeName: z.string().optional() // Optional: legacy/unmigrated machines may not have it yet
   }),
   
   // metadata: z.record(z.any()).optional(), // Future: metadata adicional si se necesita

--- a/packages/contracts/src/dashboard.contract.ts
+++ b/packages/contracts/src/dashboard.contract.ts
@@ -28,10 +28,12 @@ export const RecentQuickCheckDTOSchema = z.object({
     brand: z.string(),
     model: z.string(),
     serialNumber: z.string(),
-    machineType: z.object({
-      id: z.string(),
-      name: z.string()
-    }).optional()
+    // LEGACY: machineType object replaced by free-text machineTypeName
+    // machineType: z.object({
+    //   id: z.string(),
+    //   name: z.string()
+    // }).optional()
+    machineTypeName: z.string()
   })
 });
 
@@ -66,10 +68,12 @@ export const RecentMachineEventDTOSchema = z.object({
     id: z.string(),
     name: z.string(),
     serialNumber: z.string(),
-    machineType: z.object({
-      id: z.string(),
-      name: z.string()
-    }).optional()
+    // LEGACY: machineType object replaced by free-text machineTypeName
+    // machineType: z.object({
+    //   id: z.string(),
+    //   name: z.string()
+    // }).optional()
+    machineTypeName: z.string()
   }),
   
   // metadata: z.record(z.any()).optional(), // Future: metadata adicional si se necesita

--- a/packages/contracts/src/machine-registration.contract.ts
+++ b/packages/contracts/src/machine-registration.contract.ts
@@ -19,7 +19,9 @@ export const MachineBasicInfoSchema = z.object({
   serialNumber: BaseCreateMachineRequestSchema.shape.serialNumber,
   brand: BaseCreateMachineRequestSchema.shape.brand,
   modelName: BaseCreateMachineRequestSchema.shape.modelName,
-  machineTypeId: BaseCreateMachineRequestSchema.shape.machineTypeId,
+  // LEGACY: machineTypeId replaced by free-text machineTypeName
+  // machineTypeId: BaseCreateMachineRequestSchema.shape.machineTypeId,
+  machineTypeName: BaseCreateMachineRequestSchema.shape.machineTypeName,
   
   // Campos adicionales para el wizard UI
   name: z.string().min(2).max(100),
@@ -176,7 +178,9 @@ export const defaultMachineRegistrationData: Partial<MachineRegistrationData> = 
     serialNumber: '',
     brand: '',
     modelName: '',
-    machineTypeId: '',
+    // LEGACY: machineTypeId replaced by machineTypeName
+    // machineTypeId: '',
+    machineTypeName: '',
     name: '',
     description: '',
     nickname: '',

--- a/packages/contracts/src/machine-type.contract.ts
+++ b/packages/contracts/src/machine-type.contract.ts
@@ -1,6 +1,12 @@
 import { z } from 'zod';
 
 /**
+ * LEGACY CONTRACTS - Machine types are now free-text fields (machineTypeName).
+ * These schemas are kept for backward compatibility and potential future features.
+ * The Machine entity no longer references MachineType by ID.
+ */
+
+/**
  * Schema para crear un nuevo tipo de máquina
  */
 export const CreateMachineTypeRequestSchema = z.object({

--- a/packages/contracts/src/machine.contract.ts
+++ b/packages/contracts/src/machine.contract.ts
@@ -121,7 +121,12 @@ export const CreateMachineRequestSchema = z.object({
   modelName: z.string()
     .min(1, 'Model name is required')
     .max(100, 'Model name cannot exceed 100 characters'),
-  machineTypeId: z.string().min(1, 'Machine type ID is required'),
+  // LEGACY: machineTypeId replaced by free-text machineTypeName
+  // machineTypeId: z.string().min(1, 'Machine type ID is required'),
+  machineTypeName: z.string()
+    .min(2, 'Machine type name must be at least 2 characters')
+    .max(50, 'Machine type name cannot exceed 50 characters')
+    .trim(),
   ownerId: z.string().min(1, 'Owner ID is required'),
   createdById: z.string().min(1, 'Creator ID is required'),
   specs: MachineSpecsSchema.optional(),
@@ -157,7 +162,9 @@ export const CreateMachineResponseSchema = z.object({
   brand: z.string(),
   modelName: z.string(),
   nickname: z.string().nullable(),
-  machineTypeId: z.string(),
+  // LEGACY: machineTypeId replaced by free-text machineTypeName
+  // machineTypeId: z.string(),
+  machineTypeName: z.string(),
   ownerId: z.string(),
   createdById: z.string(),
   assignedProviderId: z.string().nullish(), // Provider assigned to machine (puede ser undefined)
@@ -196,7 +203,13 @@ export const UpdateMachineRequestSchema = z.object({
   brand: z.string().min(1).max(100).trim().optional(),
   modelName: z.string().min(1).max(100).trim().optional(),
   nickname: z.string().max(100).trim().optional(),
-  machineTypeId: z.string().min(1, 'Machine type ID is required').optional(),
+  // LEGACY: machineTypeId replaced by free-text machineTypeName
+  // machineTypeId: z.string().min(1, 'Machine type ID is required').optional(),
+  machineTypeName: z.string()
+    .min(2, 'Machine type name must be at least 2 characters')
+    .max(50, 'Machine type name cannot exceed 50 characters')
+    .trim()
+    .optional(),
   
   // Assignment
   assignedTo: z.string()
@@ -252,7 +265,8 @@ export const UpdateMachineResponseSchema = CreateMachineResponseSchema;
  */
 export const ListMachinesRequestSchema = PaginationSchema.extend({
   ownerId: z.string().optional(),
-  machineTypeId: z.string().optional(),
+  // LEGACY: machineTypeId filter removed (free-text machineTypeName not suitable for exact filtering)
+  // machineTypeId: z.string().optional(),
   status: MachineStatusCodeSchema.optional(),
   brand: z.string().optional(),
   search: z.string().optional(), // Buscar por serialNumber, brand, modelName, nickname

--- a/packages/domain/src/entities/machine/machine.entity.ts
+++ b/packages/domain/src/entities/machine/machine.entity.ts
@@ -1,6 +1,7 @@
 import { Result, ok, err, DomainError, DomainErrorCodes } from '../../errors';
 import { MachineId } from '../../value-objects/machine-id.vo';
-import { MachineTypeId } from '../../value-objects/machine-type-id.vo';
+// LEGACY: MachineTypeId no longer used by Machine entity (now free-text machineTypeName)
+// import { MachineTypeId } from '../../value-objects/machine-type-id.vo';
 import { SerialNumber } from '../../value-objects/serial-number.vo';
 import { UserId } from '../../value-objects/user-id.vo';
 import { UsageSchedule } from '../../value-objects/usage-schedule.vo';
@@ -52,7 +53,9 @@ export interface CreateMachineProps {
   serialNumber: string;
   brand: string;
   modelName: string;
-  machineTypeId: string; // Se recibe como string y se valida internamente
+  // LEGACY: machineTypeId replaced by free-text machineTypeName (Sprint #XX)
+  // machineTypeId: string; // Se recibía como string y se validaba internamente
+  machineTypeName: string; // Free-text machine type (e.g., "Autoelevador", "Excavadora")
   ownerId: string; // UserId string
   createdById: string; // UserId string
   specs?: MachineSpecs;
@@ -72,7 +75,9 @@ interface MachineProps {
   serialNumber: SerialNumber;
   brand: string;
   modelName: string;
-  machineTypeId: MachineTypeId;
+  // LEGACY: machineTypeId replaced by free-text machineTypeName (Sprint #XX)
+  // machineTypeId: MachineTypeId;
+  machineTypeName: string;
   nickname?: string;
   status: MachineStatus; // Ahora usa la clase MachineStatus
   ownerId: UserId;
@@ -109,7 +114,9 @@ export class Machine {
       brand: this.props.brand,
       modelName: this.props.modelName,
       nickname: this.props.nickname,
-      machineTypeId: this.props.machineTypeId.getValue(),
+      // LEGACY: machineTypeId replaced by machineTypeName
+      // machineTypeId: this.props.machineTypeId.getValue(),
+      machineTypeName: this.props.machineTypeName,
       ownerId: this.props.ownerId.getValue(),
       createdById: this.props.createdById.getValue(),
       assignedProviderId: this.props.assignedProviderId?.getValue(),
@@ -162,10 +169,19 @@ export class Machine {
       return err(serialNumberResult.error);
     }
 
-    // Validar machine type ID
-    const machineTypeIdResult = MachineTypeId.create(createProps.machineTypeId);
-    if (!machineTypeIdResult.success) {
-      return err(machineTypeIdResult.error);
+    // LEGACY: machineTypeId validation removed (now free-text machineTypeName)
+    // Validate machine type ID
+    // const machineTypeIdResult = MachineTypeId.create(createProps.machineTypeId);
+    // if (!machineTypeIdResult.success) {
+    //   return err(machineTypeIdResult.error);
+    // }
+
+    // Validar machineTypeName (free-text, 2-50 caracteres)
+    if (!createProps.machineTypeName || createProps.machineTypeName.trim().length < 2) {
+      return err(DomainError.validation('Machine type name must be at least 2 characters'));
+    }
+    if (createProps.machineTypeName.trim().length > 50) {
+      return err(DomainError.validation('Machine type name cannot exceed 50 characters'));
     }
 
     // Validar owner ID
@@ -218,7 +234,9 @@ export class Machine {
       serialNumber: serialNumberResult.data,
       brand: createProps.brand.trim(),
       modelName: createProps.modelName.trim(),
-      machineTypeId: machineTypeIdResult.data,
+      // LEGACY: machineTypeId replaced by machineTypeName
+      // machineTypeId: machineTypeIdResult.data,
+      machineTypeName: createProps.machineTypeName.trim(),
       nickname: createProps.nickname?.trim(),
       status: initialStatus,
       ownerId: ownerIdResult.data,
@@ -332,8 +350,13 @@ export class Machine {
     return this.props.modelName;
   }
 
-  get machineTypeId(): MachineTypeId {
-    return this.props.machineTypeId;
+  // LEGACY: machineTypeId getter replaced by machineTypeName (Sprint #XX)
+  // get machineTypeId(): MachineTypeId {
+  //   return this.props.machineTypeId;
+  // }
+
+  get machineTypeName(): string {
+    return this.props.machineTypeName;
   }
 
   get nickname(): string | undefined {

--- a/packages/domain/src/entities/machine/machine.test.ts
+++ b/packages/domain/src/entities/machine/machine.test.ts
@@ -17,7 +17,7 @@ const basicProps: CreateMachineProps = {
   serialNumber: 'CAT-320D-ABC123XYZ',
   brand: 'Caterpillar',
   modelName: '320D',
-  machineTypeId: 'mtype_excavator_001',
+  machineTypeName: 'Excavadora',
   ownerId: 'user_client_12345',
   createdById: 'user_admin_67890',
   nickname: 'Excavadora Principal'
@@ -45,7 +45,7 @@ const maintenanceProps: CreateMachineProps = {
   serialNumber: 'VOL-EC480-MNT001',
   brand: 'Volvo',
   modelName: 'EC480D',
-  machineTypeId: 'mtype_excavator_002',
+  machineTypeName: 'Excavadora',
   ownerId: 'user_client_456',
   createdById: 'user_admin_789',
   initialStatus: 'MAINTENANCE'
@@ -89,7 +89,7 @@ const fullProps: CreateMachineProps = {
   serialNumber: 'LIE-R9800-FULL001',
   brand: 'Liebherr',
   modelName: 'R9800',
-  machineTypeId: 'mtype_excavator_heavy_001',
+  machineTypeName: 'Excavadora Pesada',
   ownerId: 'user_client_789',
   createdById: 'user_admin_123',
   specs: specs,
@@ -119,7 +119,7 @@ const invalidSerial = Machine.create({
   serialNumber: 'AB', // muy corto
   brand: 'Test',
   modelName: 'Test',
-  machineTypeId: 'mtype_test_001',
+  machineTypeName: 'Test',
   ownerId: 'user_test_123',
   createdById: 'user_test_456'
 });
@@ -130,7 +130,7 @@ const invalidBrand = Machine.create({
   serialNumber: 'TEST-BRAND-001',
   brand: '',
   modelName: 'TestModel',
-  machineTypeId: 'mtype_test_001',
+  machineTypeName: 'Test',
   ownerId: 'user_test_123',
   createdById: 'user_test_456'
 });
@@ -141,7 +141,7 @@ const invalidStatus = Machine.create({
   serialNumber: 'TEST-STATUS-001',
   brand: 'TestBrand',
   modelName: 'TestModel',
-  machineTypeId: 'mtype_test_001',
+  machineTypeName: 'Test',
   ownerId: 'user_test_123',
   createdById: 'user_test_456',
   initialStatus: 'INVALID_STATUS' as any

--- a/packages/domain/src/interface-reuse-test.ts
+++ b/packages/domain/src/interface-reuse-test.ts
@@ -31,7 +31,7 @@ function testMachineInterfaceMapping() {
     serialNumber: 'CAT-2024-001',
     brand: 'Caterpillar',
     modelName: '320D',
-    machineTypeId: 'machine-type-123',
+    machineTypeName: 'Autoelevador',
     ownerId: 'user-456',
     createdById: 'admin-789',
     specs: {

--- a/packages/domain/src/models/interfaces.ts
+++ b/packages/domain/src/models/interfaces.ts
@@ -153,7 +153,9 @@ export interface IMachine extends IBaseEntity {
   readonly brand: string;
   readonly modelName: string;
   readonly nickname?: string;
-  readonly machineTypeId: string;
+  // LEGACY: machineTypeId replaced by free-text machineTypeName (Sprint #XX)
+  // readonly machineTypeId: string;
+  readonly machineTypeName: string;
   readonly ownerId: string;
   readonly createdById: string;
   readonly assignedProviderId?: string;
@@ -193,6 +195,9 @@ export interface IMachine extends IBaseEntity {
 /**
  * Interface pública mínima para MachineType
  * DRY/SSOT: Usar en dominio, contract y persistencia
+ * 
+ * LEGACY: Machine types are now free-text fields (machineTypeName).
+ * This interface is kept for backward compatibility and potential future features.
  */
 export interface IMachineType {
   readonly id: string;

--- a/packages/domain/src/ports/machine-type.repository.ts
+++ b/packages/domain/src/ports/machine-type.repository.ts
@@ -3,6 +3,9 @@ import { MachineType } from '../entities/machine-type';
 /**
  * Puerto (interface) para persistencia de MachineType
  * API simple y minimalista para tipos de máquina multilenguaje
+ * 
+ * LEGACY: Machine types are now free-text fields (machineTypeName).
+ * This repository interface is kept for backward compatibility and potential future features.
  */
 export interface IMachineTypeRepository {
   /**

--- a/packages/domain/src/ports/machine.repository.ts
+++ b/packages/domain/src/ports/machine.repository.ts
@@ -43,8 +43,30 @@ export interface IMachineRepository {
 
   /**
    * Busca máquinas por tipo
+   * 
+   * LEGACY: Machine types are now free-text (machineTypeName).
+   * This method is no longer queryable by ID after the refactoring.
+   * Kept commented for backward compatibility.
    */
-  findByMachineTypeId(typeId: MachineTypeId): Promise<Machine[]>;
+  // findByMachineTypeId(typeId: MachineTypeId): Promise<Machine[]>;
+
+  /**
+   * Busca máquinas por nombre de tipo (free-text, case-insensitive)
+   * Reemplazo de findByMachineTypeId adaptado a texto libre
+   * 
+   * @param typeName - Nombre del tipo a buscar (case-insensitive, partial match)
+   * @returns Array de máquinas que coinciden con el tipo
+   * 
+   * Casos de uso:
+   * - Estadísticas: "¿Cuántos autoelevadores tengo?"
+   * - Agrupación: Listar todas las máquinas de un tipo específico
+   * - Filtrado: Buscar máquinas similares incluso con variaciones de escritura
+   * 
+   * Ejemplos:
+   * - findByMachineTypeName("Autoelevador") → encuentra "Autoelevador", "autoelevador", "AUTOELEVADOR"
+   * - findByMachineTypeName("elev") → encuentra "Autoelevador", "elevador", "Elevadora"
+   */
+  findByMachineTypeName(typeName: string): Promise<Machine[]>;
 
   /**
    * Busca máquinas por estado
@@ -108,7 +130,8 @@ export interface IMachineRepository {
     filter?: {
       ownerId?: string;
       assignedProviderId?: string;
-      machineTypeId?: string;
+      machineTypeId?: string; // LEGACY: Kept for backward compatibility during transition
+      machineTypeName?: string; // NEW: Free-text filter for machine type (case-insensitive)
       status?: string;
       brand?: string;
       searchTerm?: string; // Busca en serialNumber, brand, modelName, nickname

--- a/packages/domain/src/value-objects/machine-type-id.vo.ts
+++ b/packages/domain/src/value-objects/machine-type-id.vo.ts
@@ -3,6 +3,9 @@ import { Result, ok, err, DomainError } from '../errors';
 /**
  * Value Object para identificar un tipo de máquina
  * Representa la referencia a una entidad MachineType
+ * 
+ * LEGACY: No longer used by Machine entity after migrating to free-text machineTypeName.
+ * Kept for backward compatibility and potential future features.
  */
 export class MachineTypeId {
   private constructor(private readonly value: string) {}

--- a/packages/persistence/src/mappers/machine.mapper.ts
+++ b/packages/persistence/src/mappers/machine.mapper.ts
@@ -69,6 +69,17 @@ export class MachineMapper {
         }
       }
 
+      // LEGACY FALLBACK: Si no existe machineTypeName (documentos legacy), usar fallback temporal
+      // Esto permite que las máquinas antiguas se carguen mientras se ejecuta la migración
+      const docAny = doc as any;
+      const machineTypeName = doc.machineTypeName || 
+                              docAny.machineTypeId || 
+                              'LEGACY-MIGRATION-REQUIRED';
+
+      if (!doc.machineTypeName) {
+        console.warn(`⚠️  Machine ${doc.id} (${doc.serialNumber}) missing machineTypeName, using fallback: "${machineTypeName}"`);
+      }
+
       // Crear la máquina con las propiedades mínimas requeridas
       const createResult = Machine.create({
         serialNumber: doc.serialNumber,
@@ -76,7 +87,7 @@ export class MachineMapper {
         modelName: doc.modelName,
         // LEGACY: machineTypeId replaced by machineTypeName
         // machineTypeId: doc.machineTypeId,
-        machineTypeName: doc.machineTypeName,
+        machineTypeName,
         ownerId: doc.ownerId,
         createdById: doc.createdById,
         nickname: doc.nickname,

--- a/packages/persistence/src/mappers/machine.mapper.ts
+++ b/packages/persistence/src/mappers/machine.mapper.ts
@@ -13,6 +13,7 @@ import {
   DayOfWeek
 } from '@packages/domain';
 import { type IMachineDocument } from '../models';
+import { logger } from '../utils/logger';
 
 /**
  * Mapper para convertir entre documentos de Mongoose y entidades de dominio Machine
@@ -70,14 +71,12 @@ export class MachineMapper {
       }
 
       // LEGACY FALLBACK: Si no existe machineTypeName (documentos legacy), usar fallback temporal
-      // Esto permite que las máquinas antiguas se carguen mientras se ejecuta la migración
-      const docAny = doc as any;
-      const machineTypeName = doc.machineTypeName || 
-                              docAny.machineTypeId || 
-                              'LEGACY-MIGRATION-REQUIRED';
+      // Esto permite que las máquinas antiguas se carguen mientras se ejecuta la migración.
+      // NOTA: NO usamos machineTypeId como fallback para evitar exponer IDs internos a los clientes.
+      const machineTypeName = doc.machineTypeName || 'LEGACY-MIGRATION-REQUIRED';
 
       if (!doc.machineTypeName) {
-        console.warn(`⚠️  Machine ${doc.id} (${doc.serialNumber}) missing machineTypeName, using fallback: "${machineTypeName}"`);
+        logger.warn({ machineId: doc.id, serialNumber: doc.serialNumber }, 'Machine missing machineTypeName, using LEGACY-MIGRATION-REQUIRED fallback');
       }
 
       // Crear la máquina con las propiedades mínimas requeridas

--- a/packages/persistence/src/mappers/machine.mapper.ts
+++ b/packages/persistence/src/mappers/machine.mapper.ts
@@ -3,7 +3,8 @@ import {
   MachineId, 
   SerialNumber, 
   UserId, 
-  MachineTypeId,
+  // LEGACY: MachineTypeId no longer used (now free-text machineTypeName)
+  // MachineTypeId,
   MachineStatusRegistry,
   UsageSchedule,
   type MachineSpecs,
@@ -73,7 +74,9 @@ export class MachineMapper {
         serialNumber: doc.serialNumber,
         brand: doc.brand,
         modelName: doc.modelName,
-        machineTypeId: doc.machineTypeId,
+        // LEGACY: machineTypeId replaced by machineTypeName
+        // machineTypeId: doc.machineTypeId,
+        machineTypeName: doc.machineTypeName,
         ownerId: doc.ownerId,
         createdById: doc.createdById,
         nickname: doc.nickname,
@@ -189,7 +192,9 @@ export class MachineMapper {
       brand: publicInterface.brand,
       modelName: publicInterface.modelName,
       nickname: publicInterface.nickname,
-      machineTypeId: publicInterface.machineTypeId,
+      // LEGACY: machineTypeId replaced by machineTypeName
+      // machineTypeId: publicInterface.machineTypeId,
+      machineTypeName: publicInterface.machineTypeName,
       ownerId: publicInterface.ownerId,
       createdById: publicInterface.createdById,
       assignedProviderId: publicInterface.assignedProviderId,

--- a/packages/persistence/src/models/machine-type.model.ts
+++ b/packages/persistence/src/models/machine-type.model.ts
@@ -3,6 +3,12 @@ import { Schema, model, Document, type Types } from 'mongoose';
 import { type IMachineType } from '@packages/domain';
 
 /**
+ * LEGACY MODEL - Machine types are now free-text fields (machineTypeName).
+ * This model is kept for data migration and potential future features.
+ * The Machine model no longer references MachineType documents.
+ */
+
+/**
  * MachineType Document interface extending domain IMachineType
  * Excluimos 'id' (usamos _id virtual)
  */

--- a/packages/persistence/src/models/machine.model.ts
+++ b/packages/persistence/src/models/machine.model.ts
@@ -454,6 +454,8 @@ machineSchema.index({ ownerId: 1, 'status.code': 1 });
 machineSchema.index({ assignedProviderId: 1, 'status.isOperational': 1 });
 // LEGACY: machineTypeId index removed (now free-text machineTypeName)
 // machineSchema.index({ machineTypeId: 1, 'status.code': 1 });
+// NEW: machineTypeName index for type-based filtering and grouping
+machineSchema.index({ machineTypeName: 1, 'status.code': 1 });
 machineSchema.index({ brand: 1, modelName: 1 });
 
 // 🆕 Sprint #10: Indexes para queries de eventsHistory (embedded array)
@@ -474,6 +476,7 @@ machineSchema.index({
   serialNumber: 'text',
   brand: 'text',
   modelName: 'text',
+  machineTypeName: 'text', // NEW: included for text search by type name
   nickname: 'text',
   'location.siteName': 'text',
   'location.address': 'text'

--- a/packages/persistence/src/models/machine.model.ts
+++ b/packages/persistence/src/models/machine.model.ts
@@ -66,10 +66,19 @@ const machineSchema = new Schema<IMachineDocument>({
     sparse: true
   },
   
-  machineTypeId: {
+  // LEGACY: machineTypeId replaced by free-text machineTypeName (Sprint #XX)
+  // machineTypeId: {
+  //   type: String,
+  //   required: true,
+  //   ref: 'MachineType'
+  // },
+
+  machineTypeName: {
     type: String,
     required: true,
-    ref: 'MachineType'
+    trim: true,
+    minlength: 2,
+    maxlength: 50
   },
   
   ownerId: {
@@ -443,7 +452,8 @@ machineSchema.set('toJSON', {
 // Compound indexes for performance
 machineSchema.index({ ownerId: 1, 'status.code': 1 });
 machineSchema.index({ assignedProviderId: 1, 'status.isOperational': 1 });
-machineSchema.index({ machineTypeId: 1, 'status.code': 1 });
+// LEGACY: machineTypeId index removed (now free-text machineTypeName)
+// machineSchema.index({ machineTypeId: 1, 'status.code': 1 });
 machineSchema.index({ brand: 1, modelName: 1 });
 
 // 🆕 Sprint #10: Indexes para queries de eventsHistory (embedded array)

--- a/packages/persistence/src/repositories/machine-type.repository.ts
+++ b/packages/persistence/src/repositories/machine-type.repository.ts
@@ -2,6 +2,12 @@ import { MachineType, type IMachineTypeRepository } from '@packages/domain';
 import { MachineTypeModel, type IMachineTypeDocument } from '../models';
 
 /**
+ * LEGACY REPOSITORY - Machine types are now free-text fields (machineTypeName).
+ * This repository is kept for data migration and potential future features.
+ * The Machine entity no longer references MachineType by ID.
+ */
+
+/**
  * Implementación del repositorio de MachineType
  * Incluye lógica inteligente de save para manejar multilenguaje
  */

--- a/packages/persistence/src/repositories/machine.repository.ts
+++ b/packages/persistence/src/repositories/machine.repository.ts
@@ -133,13 +133,44 @@ export class MachineRepository implements IMachineRepository {
 
   /**
    * Busca máquinas por tipo
+   * 
+   * LEGACY: Machine types are now free-text (machineTypeName).
+   * This method is no longer queryable by ID after the refactoring.
+   * Kept commented for reference.
    */
-  async findByMachineTypeId(typeId: MachineTypeId): Promise<Machine[]> {
+  // async findByMachineTypeId(typeId: MachineTypeId): Promise<Machine[]> {
+  //   try {
+  //     const docs = await MachineModel.find({ machineTypeId: typeId.getValue() }).sort({ createdAt: -1 });
+  //     return MachineMapper.toEntityArray(docs);
+  //   } catch (error) {
+  //     logger.error({ error }, 'Error finding machines by machine type ID');
+  //     return [];
+  //   }
+  // }
+
+  /**
+   * Busca máquinas por nombre de tipo (free-text, case-insensitive)
+   * Reemplazo de findByMachineTypeId adaptado a texto libre
+   * 
+   * @param typeName - Nombre del tipo a buscar (case-insensitive, partial match)
+   * @returns Array de máquinas que coinciden con el tipo
+   * 
+   * Ejemplos:
+   * - "Autoelevador" encuentra: "Autoelevador", "autoelevador", "AUTOELEVADOR"
+   * - "elev" encuentra: "Autoelevador", "elevador"
+   * 
+   * Nota: Útil para estadísticas y agrupación por tipo, incluso con variaciones de escritura.
+   */
+  async findByMachineTypeName(typeName: string): Promise<Machine[]> {
     try {
-      const docs = await MachineModel.find({ machineTypeId: typeId.getValue() }).sort({ createdAt: -1 });
+      const docs = await MachineModel.find({ 
+        machineTypeName: { $regex: typeName, $options: 'i' } 
+      }).sort({ createdAt: -1 });
+      
+      logger.debug({ typeName, count: docs.length }, 'Found machines by type name');
       return MachineMapper.toEntityArray(docs);
     } catch (error) {
-      logger.error({ error }, 'Error finding machines by machine type ID');
+      logger.error({ error, typeName }, 'Error finding machines by machine type name');
       return [];
     }
   }
@@ -459,7 +490,8 @@ export class MachineRepository implements IMachineRepository {
     filter?: {
       ownerId?: string;
       assignedProviderId?: string;
-      machineTypeId?: string;
+      machineTypeId?: string; // LEGACY: Kept for backward compatibility
+      machineTypeName?: string; // NEW: Free-text filter for machine type
       status?: string;
       brand?: string;
       searchTerm?: string;
@@ -485,8 +517,14 @@ export class MachineRepository implements IMachineRepository {
         query.assignedProviderId = options.filter.assignedProviderId;
       }
       
-      if (options.filter?.machineTypeId) {
-        query.machineTypeId = options.filter.machineTypeId;
+      // LEGACY: machineTypeId filter removed (now free-text machineTypeName)
+      // if (options.filter?.machineTypeId) {
+      //   query.machineTypeId = options.filter.machineTypeId;
+      // }
+
+      // NEW: Free-text machineTypeName filter (case-insensitive partial match)
+      if (options.filter?.machineTypeName) {
+        query.machineTypeName = { $regex: options.filter.machineTypeName, $options: 'i' };
       }
       
       if (options.filter?.status) {

--- a/packages/persistence/src/repositories/machine.repository.ts
+++ b/packages/persistence/src/repositories/machine.repository.ts
@@ -23,6 +23,15 @@ import { type CreateQuickCheckRecord, type QuickCheckHistoryFilters } from '@pac
 import { logger } from '../utils/logger';
 
 /**
+ * Escapes special regex metacharacters in a string so it can be used as a
+ * literal substring pattern in a MongoDB $regex query.
+ * Prevents ReDoS and accidental wildcard matches from user-supplied input.
+ */
+function escapeRegex(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
  * Tipo para agregar evento (sin machineId porque se pasa por separado)
  * Agrega isSystemGenerated como opcional (para eventos generados por el sistema)
  */
@@ -163,8 +172,9 @@ export class MachineRepository implements IMachineRepository {
    */
   async findByMachineTypeName(typeName: string): Promise<Machine[]> {
     try {
+      if (!typeName.trim()) return [];
       const docs = await MachineModel.find({ 
-        machineTypeName: { $regex: typeName, $options: 'i' } 
+        machineTypeName: { $regex: escapeRegex(typeName), $options: 'i' } 
       }).sort({ createdAt: -1 });
       
       logger.debug({ typeName, count: docs.length }, 'Found machines by type name');
@@ -523,8 +533,8 @@ export class MachineRepository implements IMachineRepository {
       // }
 
       // NEW: Free-text machineTypeName filter (case-insensitive partial match)
-      if (options.filter?.machineTypeName) {
-        query.machineTypeName = { $regex: options.filter.machineTypeName, $options: 'i' };
+      if (options.filter?.machineTypeName?.trim()) {
+        query.machineTypeName = { $regex: escapeRegex(options.filter.machineTypeName), $options: 'i' };
       }
       
       if (options.filter?.status) {


### PR DESCRIPTION
This pull request introduces a major refactor to how machine types are managed across the backend. The system transitions from using a referenced `machineTypeId` (linked to a separate `MachineType` collection) to a free-text `machineTypeName` field stored directly on each machine. This change simplifies machine creation, updates, and filtering, and deprecates the need for strict referential integrity with the `MachineType` collection. Legacy code, controllers, and routes related to machine types are retained for backward compatibility and for providing UI suggestions, but are clearly marked as non-critical. The migration is handled automatically at startup.

**Key changes include:**

### 1. Machine Type Model Refactor

- All references to `machineTypeId` in machine creation, update, filtering, and API responses are replaced with a free-text `machineTypeName` field (2–50 characters). This affects use cases, controllers, and route schemas. [[1]](diffhunk://#diff-0add004ba6211c4eeb85eca9db696ae335f320e0dd5abf5667b7ecafcb536ecfL65-R67) [[2]](diffhunk://#diff-1cfdff895d1d7f2c1c9d6392748c0d31a38a0a20d2178cdb7c285d63751190d9L67-R78) [[3]](diffhunk://#diff-134d8c4389dd2cb83482679406668c99467ec7d636bc9d786d5b653c8da10edeL51-R51) [[4]](diffhunk://#diff-8b98378c4bb8822d8e34d1f185fd1b932c80dcd4c6bac3e6a45ac06ba3e79844L63-R65) [[5]](diffhunk://#diff-b363611befb9bf3ea1e34a091069925916eb0c4f6967db6bdd1290f8e43c9866L47-R50) [[6]](diffhunk://#diff-b363611befb9bf3ea1e34a091069925916eb0c4f6967db6bdd1290f8e43c9866L87-R88) [[7]](diffhunk://#diff-b363611befb9bf3ea1e34a091069925916eb0c4f6967db6bdd1290f8e43c9866L98-R102) [[8]](diffhunk://#diff-acc5f07ca85ff740a9167d1c710b840b1aca98017f0d0715928a93d3fa37d243L88-R88) [[9]](diffhunk://#diff-64b38028573d9afbecb2ebc5251931046d87eaeb572b212ebdcdb861ed560da7L95-R95)

- All validation and repository lookups for `machineTypeId` are removed from the codebase, with legacy code commented and annotated for clarity. [[1]](diffhunk://#diff-0add004ba6211c4eeb85eca9db696ae335f320e0dd5abf5667b7ecafcb536ecfL14-R21) [[2]](diffhunk://#diff-0add004ba6211c4eeb85eca9db696ae335f320e0dd5abf5667b7ecafcb536ecfL41-R47) [[3]](diffhunk://#diff-0add004ba6211c4eeb85eca9db696ae335f320e0dd5abf5667b7ecafcb536ecfL102-R105) [[4]](diffhunk://#diff-0add004ba6211c4eeb85eca9db696ae335f320e0dd5abf5667b7ecafcb536ecfL2-R2)

### 2. Legacy Support and Documentation

- All use cases, controllers, and routes related to `MachineType` are now clearly marked as "LEGACY". They are retained only for backward compatibility, initial seeding, and providing suggestions for UI dropdowns. Extensive comments document the new architecture and the rationale behind keeping legacy code. [[1]](diffhunk://#diff-42d268a0a8b98afb930131a085c64bce79e51610c0d125aa0cdf28318b705f65R7-R11) [[2]](diffhunk://#diff-a8211a497e047079ad9c3b04874a1a4b87334766481edf24cf9e2995c4e2a6eeR5-R9) [[3]](diffhunk://#diff-a8211a497e047079ad9c3b04874a1a4b87334766481edf24cf9e2995c4e2a6eeL13-R20) [[4]](diffhunk://#diff-a8211a497e047079ad9c3b04874a1a4b87334766481edf24cf9e2995c4e2a6eeL50-R47) [[5]](diffhunk://#diff-07ce30dd73f8e45e0e96c00617b2dfe71d8d0f4f4a190081cf4272e9c4ea76d8R6-R13) [[6]](diffhunk://#diff-5c3b24d8272b2059b7c87725c8d682482802c23ad1815d5bbd7a84af29917aa9R7-R11) [[7]](diffhunk://#diff-b07766434cd669c46402d590a5535f13f9e2b993ef496cf134793d7c8b032549L12-R20) [[8]](diffhunk://#diff-34911aa7886224fc0bc1fc954f7fa46e41be6c01ced63a6e8a54fcb8e491cb37R16-R24)

### 3. Data Migration and Startup Logic

- A new migration script, `migrateMachineTypeToText`, is integrated into the server startup. It automatically migrates existing machines from `machineTypeId` to `machineTypeName` if needed, with logging and error handling to ensure a smooth transition. [[1]](diffhunk://#diff-c1c355744d2120ce1cadf340329e8ac7cbb47cf17fd86bb0f70fa25d324f3678R16) [[2]](diffhunk://#diff-c1c355744d2120ce1cadf340329e8ac7cbb47cf17fd86bb0f70fa25d324f3678R132-R154)

### 4. API and Documentation Updates

- All API route schemas, request/response objects, and OpenAPI documentation are updated to reflect the new `machineTypeName` field and to clarify that it is now a free-text field. [[1]](diffhunk://#diff-b363611befb9bf3ea1e34a091069925916eb0c4f6967db6bdd1290f8e43c9866L47-R50) [[2]](diffhunk://#diff-b363611befb9bf3ea1e34a091069925916eb0c4f6967db6bdd1290f8e43c9866L87-R88) [[3]](diffhunk://#diff-b363611befb9bf3ea1e34a091069925916eb0c4f6967db6bdd1290f8e43c9866L98-R102)

---

This refactor streamlines machine management, removes unnecessary complexity, and paves the way for more flexible machine type handling in the future.